### PR TITLE
Bitcoin interface poller

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -1,9 +1,9 @@
 ///! Implementation of the Bitcoin interface using bitcoind.
 ///!
 ///! We use the RPC interface and a watchonly descriptor wallet.
-use crate::config;
+use crate::{bitcoin::BlockChainTip, config};
 
-use std::{fs, io, time::Duration};
+use std::{convert::TryInto, fs, io, str::FromStr, time::Duration};
 
 use jsonrpc::{
     arg,
@@ -478,13 +478,47 @@ impl BitcoinD {
         Ok(())
     }
 
+    fn block_chain_info(&self) -> Json {
+        self.make_node_request("getblockchaininfo", &[])
+    }
+
     pub fn sync_progress(&self) -> f64 {
         // TODO: don't harass revaultd, be smarter like in revaultd.
         roundup_progress(
-            self.make_node_request("getblockchaininfo", &[])
+            self.block_chain_info()
                 .get("verificationprogress")
                 .and_then(Json::as_f64)
                 .expect("No valid 'verificationprogress' in getblockchaininfo response?"),
+        )
+    }
+
+    pub fn chain_tip(&self) -> BlockChainTip {
+        // We use getblockchaininfo to avoid a race between getblockcount and getblockhash
+        let chain_info = self.block_chain_info();
+        let hash = bitcoin::BlockHash::from_str(
+            chain_info
+                .get("bestblockhash")
+                .and_then(Json::as_str)
+                .expect("No valid 'bestblockhash' in 'getblockchaininfo' response?"),
+        )
+        .expect("Invalid blockhash from bitcoind?");
+        let height: i32 = chain_info
+            .get("blocks")
+            .and_then(Json::as_i64)
+            .expect("No valid 'blocks' in 'getblockchaininfo' response?")
+            .try_into()
+            .expect("Must fit by Bitcoin consensus");
+
+        BlockChainTip { hash, height }
+    }
+
+    pub fn get_block_hash(&self, height: i32) -> Option<bitcoin::BlockHash> {
+        Some(
+            self.make_fallible_node_request("getblockhash", &params!(Json::Number(height.into()),))
+                .ok()?
+                .as_str()
+                .and_then(|s| bitcoin::BlockHash::from_str(s).ok())
+                .expect("bitcoind must send valid block hashes"),
         )
     }
 }
@@ -495,7 +529,7 @@ fn roundup_progress(progress: f64) -> f64 {
     let precision = 10u64.pow(5) as f64;
     let progress_rounded = (progress * precision + 1.0) as u64;
 
-    if progress_rounded * 10 >= precision as u64 {
+    if progress_rounded >= precision as u64 {
         1.0
     } else {
         (progress_rounded as f64 / precision) as f64

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -2,5 +2,19 @@
 ///!
 ///! Broadcast transactions, poll for new unspent coins, gather fee estimates.
 pub mod d;
+pub mod poller;
 
-pub trait BitcoinInterface {}
+use std::sync;
+
+/// Our Bitcoin backend.
+pub trait BitcoinInterface: Send {
+    /// Get the progress of the block chain synchronization.
+    /// Returns a percentage between 0 and 1.
+    fn sync_progress(&self) -> f64;
+}
+
+impl BitcoinInterface for sync::Arc<sync::RwLock<d::BitcoinD>> {
+    fn sync_progress(&self) -> f64 {
+        self.read().unwrap().sync_progress()
+    }
+}

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -6,15 +6,42 @@ pub mod poller;
 
 use std::sync;
 
+use miniscript::bitcoin;
+
+/// Information about the best block in the chain
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BlockChainTip {
+    pub hash: bitcoin::BlockHash,
+    pub height: i32,
+}
+
 /// Our Bitcoin backend.
 pub trait BitcoinInterface: Send {
     /// Get the progress of the block chain synchronization.
     /// Returns a percentage between 0 and 1.
     fn sync_progress(&self) -> f64;
+
+    /// Get the best block info.
+    fn chain_tip(&self) -> BlockChainTip;
+
+    /// Check whether this former tip is part of the current best chain.
+    fn is_in_chain(&self, tip: &BlockChainTip) -> bool;
 }
 
 impl BitcoinInterface for sync::Arc<sync::RwLock<d::BitcoinD>> {
     fn sync_progress(&self) -> f64 {
         self.read().unwrap().sync_progress()
+    }
+
+    fn chain_tip(&self) -> BlockChainTip {
+        self.read().unwrap().chain_tip()
+    }
+
+    fn is_in_chain(&self, tip: &BlockChainTip) -> bool {
+        self.read()
+            .unwrap()
+            .get_block_hash(tip.height)
+            .map(|bh| bh == tip.hash)
+            .unwrap_or(false)
     }
 }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,0 +1,46 @@
+use crate::bitcoin::BitcoinInterface;
+
+use std::{
+    sync::{self, atomic},
+    thread, time,
+};
+
+/// Main event loop. Repeatedly polls the Bitcoin interface until told to stop through the
+/// `shutdown` atomic.
+pub fn looper(
+    bit: impl BitcoinInterface,
+    shutdown: sync::Arc<atomic::AtomicBool>,
+    poll_interval: time::Duration,
+) {
+    let mut last_poll = None;
+    let mut synced = false;
+
+    while !shutdown.load(atomic::Ordering::Relaxed) || last_poll.is_none() {
+        let now = time::Instant::now();
+
+        if let Some(last_poll) = last_poll {
+            if now.duration_since(last_poll) < poll_interval {
+                thread::sleep(time::Duration::from_millis(500));
+                continue;
+            }
+        }
+        last_poll = Some(now);
+
+        // Don't poll until the Bitcoin backend is fully synced.
+        if !synced {
+            let sync_progress = bit.sync_progress();
+            log::info!(
+                "Block chain synchronization progress: {:.2}%",
+                sync_progress
+            );
+            synced = sync_progress == 1.0;
+            if !synced {
+                // Avoid harassing bitcoind..
+                // TODO: be smarter, like in revaultd, but more generic too.
+                #[cfg(not(test))]
+                thread::sleep(time::Duration::from_secs(30));
+                continue;
+            }
+        }
+    }
+}

--- a/src/bitcoin/poller/mod.rs
+++ b/src/bitcoin/poller/mod.rs
@@ -1,0 +1,31 @@
+mod looper;
+
+use crate::bitcoin::{poller::looper::looper, BitcoinInterface};
+
+use std::{
+    sync::{self, atomic},
+    thread, time,
+};
+
+/// The Bitcoin poller handler.
+pub struct Poller {
+    handle: thread::JoinHandle<()>,
+    shutdown: sync::Arc<atomic::AtomicBool>,
+}
+
+impl Poller {
+    pub fn start(bit: impl BitcoinInterface + 'static, poll_interval: time::Duration) -> Poller {
+        let shutdown = sync::Arc::from(atomic::AtomicBool::from(false));
+        let handle = thread::spawn({
+            let shutdown = shutdown.clone();
+            move || looper(bit, shutdown, poll_interval)
+        });
+
+        Poller { shutdown, handle }
+    }
+
+    pub fn stop(self) {
+        self.shutdown.store(true, atomic::Ordering::Relaxed);
+        self.handle.join().expect("The poller loop must not fail");
+    }
+}

--- a/src/bitcoin/poller/mod.rs
+++ b/src/bitcoin/poller/mod.rs
@@ -1,6 +1,9 @@
 mod looper;
 
-use crate::bitcoin::{poller::looper::looper, BitcoinInterface};
+use crate::{
+    bitcoin::{poller::looper::looper, BitcoinInterface},
+    database::DatabaseInterface,
+};
 
 use std::{
     sync::{self, atomic},
@@ -14,11 +17,15 @@ pub struct Poller {
 }
 
 impl Poller {
-    pub fn start(bit: impl BitcoinInterface + 'static, poll_interval: time::Duration) -> Poller {
+    pub fn start(
+        bit: impl BitcoinInterface + 'static,
+        db: impl DatabaseInterface + 'static,
+        poll_interval: time::Duration,
+    ) -> Poller {
         let shutdown = sync::Arc::from(atomic::AtomicBool::from(false));
         let handle = thread::spawn({
             let shutdown = shutdown.clone();
-            move || looper(bit, shutdown, poll_interval)
+            move || looper(bit, db, shutdown, poll_interval)
         });
 
         Poller { shutdown, handle }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3,4 +3,42 @@
 ///! Record wallet metadata, spent and unspent coins, ongoing transactions.
 pub mod sqlite;
 
-pub trait DatabaseInterface {}
+use crate::{
+    bitcoin::BlockChainTip,
+    database::sqlite::{schema::DbTip, SqliteConn, SqliteDb},
+};
+
+pub trait DatabaseInterface: Send {
+    fn connection(&self) -> Box<dyn DatabaseConnection>;
+}
+
+impl DatabaseInterface for SqliteDb {
+    fn connection(&self) -> Box<dyn DatabaseConnection> {
+        Box::new(self.connection().expect("Database must be available"))
+    }
+}
+
+pub trait DatabaseConnection {
+    /// Get the tip of the best chain we've seen.
+    fn chain_tip(&mut self) -> Option<BlockChainTip>;
+
+    /// Update our best chain seen.
+    fn update_tip(&mut self, tip: &BlockChainTip);
+}
+
+impl DatabaseConnection for SqliteConn {
+    fn chain_tip(&mut self) -> Option<BlockChainTip> {
+        match self.db_tip() {
+            DbTip {
+                block_height: Some(height),
+                block_hash: Some(hash),
+                ..
+            } => Some(BlockChainTip { height, hash }),
+            _ => None,
+        }
+    }
+
+    fn update_tip(&mut self, tip: &BlockChainTip) {
+        self.update_tip(&tip)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,8 +194,11 @@ impl DaemonHandle {
 
         // Spawn the bitcoind poller with a retry limit high enough that we'd fail after that.
         let bitcoind = sync::Arc::from(sync::RwLock::from(bitcoind.with_retry_limit(None)));
-        let bit_poller =
-            poller::Poller::start(bitcoind.clone(), config.bitcoind_config.poll_interval_secs);
+        let bit_poller = poller::Poller::start(
+            bitcoind.clone(),
+            db,
+            config.bitcoind_config.poll_interval_secs,
+        );
         bit_poller.stop();
 
         Ok(Self {})


### PR DESCRIPTION
This introduces the Bitcoin poller, an event loop in a new thread that continuously poll our Bitcoin backend to update our state. This is kept minimal; only introduce the necessary components (Bitcoin interface, DB interface) and as such it only takes care of updating the best tip at the moment.