### PR TITLE
Introduce the `commands` module

### DIFF
--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -58,10 +58,11 @@ fn main() {
         process::exit(1);
     });
 
-    let _ = DaemonHandle::start(config).unwrap_or_else(|e| {
+    let daemon = DaemonHandle::start(config).unwrap_or_else(|e| {
         // The panic hook will log::error
         panic!("Starting Minisafe daemon: {}", e);
     });
+    daemon.shutdown();
 
     // We are always logging to stdout, should it be then piped to the log file (if self) or
     // not. So just make sure that all messages were actually written.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,37 @@
+//! # Minisafe commands
+//!
+//! External interface to the Minisafe daemon.
+
+use crate::{DaemonControl, VERSION};
+
+use miniscript::{bitcoin, descriptor};
+
+impl DaemonControl {
+    /// Get information about the current state of the daemon
+    pub fn get_info(&self) -> GetInfoResult {
+        GetInfoResult {
+            version: VERSION.to_string(),
+            network: self.config.bitcoind_config.network,
+            blockheight: self.bitcoin.chain_tip().height,
+            sync: self.bitcoin.sync_progress(),
+            descriptors: GetInfoDescriptors {
+                main: self.config.main_descriptor.clone(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetInfoDescriptors {
+    pub main: descriptor::Descriptor<descriptor::DescriptorPublicKey>,
+}
+
+/// Information about the daemon
+#[derive(Debug, Clone)]
+pub struct GetInfoResult {
+    pub version: String,
+    pub network: bitcoin::Network,
+    pub blockheight: i32,
+    pub sync: f64,
+    pub descriptors: GetInfoDescriptors,
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -8,6 +8,8 @@ use crate::{
     database::sqlite::{schema::DbTip, SqliteConn, SqliteDb},
 };
 
+use miniscript::bitcoin::util::bip32;
+
 pub trait DatabaseInterface: Send {
     fn connection(&self) -> Box<dyn DatabaseConnection>;
 }
@@ -24,6 +26,10 @@ pub trait DatabaseConnection {
 
     /// Update our best chain seen.
     fn update_tip(&mut self, tip: &BlockChainTip);
+
+    fn derivation_index(&mut self) -> bip32::ChildNumber;
+
+    fn update_derivation_index(&mut self, index: bip32::ChildNumber);
 }
 
 impl DatabaseConnection for SqliteConn {
@@ -40,5 +46,13 @@ impl DatabaseConnection for SqliteConn {
 
     fn update_tip(&mut self, tip: &BlockChainTip) {
         self.update_tip(&tip)
+    }
+
+    fn derivation_index(&mut self) -> bip32::ChildNumber {
+        self.db_wallet().deposit_derivation_index
+    }
+
+    fn update_derivation_index(&mut self, index: bip32::ChildNumber) {
+        self.update_derivation_index(index)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,20 @@ fn setup_panic_hook() {
     }));
 }
 
+#[derive(Debug, Clone)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+pub const VERSION: Version = Version { major: 0, minor: 1 };
+
 #[derive(Debug)]
 pub enum StartupError {
     Io(io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod bitcoin;
+mod commands;
 pub mod config;
 #[cfg(unix)]
 mod daemonize;


### PR DESCRIPTION
This module contains the implementation of our external API. Like the others, it's very inspired (or grossly copied from) `revaultd`.

This PR implements the `getinfo` and `getnewaddress` commands to showcase the usage of the new `DaemonControl` command.