### PR TITLE
Typesafe descriptor management

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -64,3 +64,23 @@ This command does not take any parameter for now.
 | Field         | Type   | Description        |
 | ------------- | ------ | ------------------ |
 | `address`     | string | A Bitcoin address  |
+
+
+### `listcoins`
+
+List our current Unspent Transaction Outputs.
+
+#### Request
+
+This command does not take any parameter for now.
+
+| Field         | Type              | Description                                                 |
+| ------------- | ----------------- | ----------------------------------------------------------- |
+
+#### Response
+
+| Field          | Type          | Description                                                      |
+| -------------- | ------------- | ---------------------------------------------------------------- |
+| `amount`       | int           | Value of the UTxO in satoshis                                    |
+| `outpoint`     | string        | Transaction id and output index of this coin                     |
+| `block_height` | int or null   | Blockheight the transaction was confirmed at, or `null`          |

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -1,7 +1,7 @@
 ///! Implementation of the Bitcoin interface using bitcoind.
 ///!
 ///! We use the RPC interface and a watchonly descriptor wallet.
-use crate::{bitcoin::BlockChainTip, config};
+use crate::{bitcoin::BlockChainTip, config, descriptors::InheritanceDescriptor};
 
 use std::{collections::HashSet, convert::TryInto, fs, io, str::FromStr, time::Duration};
 
@@ -10,7 +10,7 @@ use jsonrpc::{
     client::Client,
     simple_http::{self, SimpleHttpTransport},
 };
-use miniscript::{bitcoin, Descriptor, DescriptorPublicKey};
+use miniscript::bitcoin;
 
 use serde_json::Value as Json;
 
@@ -354,7 +354,7 @@ impl BitcoinD {
     }
 
     // TODO: rescan feature will probably need another timestamp than 'now'
-    fn import_descriptor(&self, descriptor: &Descriptor<DescriptorPublicKey>) -> Option<String> {
+    fn import_descriptor(&self, descriptor: &InheritanceDescriptor) -> Option<String> {
         let descriptors = vec![serde_json::json!({
             "desc": descriptor.to_string(),
             "timestamp": "now",
@@ -400,7 +400,7 @@ impl BitcoinD {
     /// Create the watchonly wallet on bitcoind, and import it the main descriptor.
     pub fn create_watchonly_wallet(
         &self,
-        main_descriptor: &Descriptor<DescriptorPublicKey>,
+        main_descriptor: &InheritanceDescriptor,
     ) -> Result<(), BitcoindError> {
         // Remove any leftover. This can happen if we delete the watchonly wallet but don't restart
         // bitcoind.
@@ -440,7 +440,7 @@ impl BitcoinD {
     /// Perform various sanity checks on the bitcoind instance.
     pub fn sanity_check(
         &self,
-        main_descriptor: &Descriptor<DescriptorPublicKey>,
+        main_descriptor: &InheritanceDescriptor,
         config_network: bitcoin::Network,
     ) -> Result<(), BitcoindError> {
         // Check the minimum supported bitcoind version

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -671,11 +671,12 @@ fn roundup_progress(progress: f64) -> f64 {
 }
 
 /// A 'received' entry in the 'listsinceblock' result.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct LSBlockEntry {
     pub outpoint: bitcoin::OutPoint,
     pub amount: bitcoin::Amount,
     pub block_height: Option<i32>,
+    pub address: bitcoin::Address,
 }
 
 impl From<&Json> for LSBlockEntry {
@@ -702,10 +703,17 @@ impl From<&Json> for LSBlockEntry {
             .and_then(Json::as_i64)
             .map(|bh| bh as i32);
 
+        let address = json
+            .get("address")
+            .and_then(Json::as_str)
+            .and_then(|s| bitcoin::Address::from_str(s).ok())
+            .expect("bitcoind can't give a bad address");
+
         LSBlockEntry {
             outpoint,
             amount,
             block_height,
+            address,
         }
     }
 }

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -3,7 +3,7 @@
 ///! We use the RPC interface and a watchonly descriptor wallet.
 use crate::{bitcoin::BlockChainTip, config};
 
-use std::{convert::TryInto, fs, io, str::FromStr, time::Duration};
+use std::{collections::HashSet, convert::TryInto, fs, io, str::FromStr, time::Duration};
 
 use jsonrpc::{
     arg,
@@ -278,6 +278,14 @@ impl BitcoinD {
             .expect("We must not fail to make a request for more than a minute")
     }
 
+    fn make_faillible_wallet_request(
+        &self,
+        method: &str,
+        params: &[Box<serde_json::value::RawValue>],
+    ) -> Result<Json, BitcoindError> {
+        self.make_request(&self.watchonly_client, method, params)
+    }
+
     fn get_bitcoind_version(&self) -> u64 {
         self.make_node_request("getnetworkinfo", &[])
             .get("version")
@@ -521,8 +529,134 @@ impl BitcoinD {
                 .expect("bitcoind must send valid block hashes"),
         )
     }
-}
 
+    pub fn list_since_block(&self, block_hash: &bitcoin::BlockHash) -> LSBlockRes {
+        self.make_wallet_request(
+            "listsinceblock",
+            &params!(Json::String(block_hash.to_string()),),
+        )
+        .into()
+    }
+
+    pub fn get_transaction(&self, txid: &bitcoin::Txid) -> Option<GetTxRes> {
+        // TODO: Maybe assert we got a -5 error, and not any other kind of error?
+        self.make_faillible_wallet_request(
+            "gettransaction",
+            &params!(Json::String(txid.to_string())),
+        )
+        .ok()
+        .map(|res| res.into())
+    }
+
+    /// Efficient check that a coin is spent.
+    pub fn is_spent(&self, op: &bitcoin::OutPoint) -> bool {
+        // The result of gettxout is empty if the outpoint is spent.
+        self.make_node_request(
+            "gettxout",
+            &params!(
+                Json::String(op.txid.to_string()),
+                Json::Number(op.vout.into())
+            ),
+        )
+        .get("bestblock")
+        .is_none()
+    }
+
+    /// So, bitcoind has no API for getting the transaction spending a wallet UTXO. Instead we are
+    /// therefore using a rather convoluted way to get it the other way around, since the spending
+    /// transaction is actually *part of the wallet transactions*.
+    /// So, what we do there is listing all outgoing transactions of the wallet since the last poll
+    /// and iterating through each of those to check if it spends the transaction we are interested
+    /// in (requiring an other RPC call for each!!).
+    pub fn get_spender_txid(&self, spent_outpoint: &bitcoin::OutPoint) -> Option<bitcoin::Txid> {
+        // Get the hash of the block parent of the spent transaction's block.
+        let req = self.make_wallet_request(
+            "gettransaction",
+            &params!(Json::String(spent_outpoint.txid.to_string())),
+        );
+        let spent_tx_height = match req.get("blockheight").and_then(Json::as_i64) {
+            Some(h) => h,
+            // FIXME: we assume it's confirmed. If we were to change the logic in the poller, we'd
+            // need to handle it here.
+            None => return None,
+        };
+        let block_hash = if let Ok(res) = self.make_fallible_node_request(
+            "getblockhash",
+            &params!(Json::Number((spent_tx_height - 1).into())),
+        ) {
+            res.as_str()
+                .expect("'getblockhash' result isn't a string")
+                .to_string()
+        } else {
+            // Possibly a race.
+            return None;
+        };
+
+        // Now we can get all transactions related to us since the spent transaction confirmed.
+        // We'll use it to locate the spender.
+        let lsb_res =
+            self.make_wallet_request("listsinceblock", &params!(Json::String(block_hash)));
+        let transactions = lsb_res
+            .get("transactions")
+            .and_then(Json::as_array)
+            .expect("tx array must be there");
+
+        // Get the spent txid to ignore the entries about this transaction
+        let spent_txid = spent_outpoint.txid.to_string();
+        // We use a cache to avoid needless iterations, since listsinceblock returns an entry
+        // per transaction output, not per transaction.
+        let mut visited_txs = HashSet::with_capacity(transactions.len());
+        for transaction in transactions {
+            if transaction.get("category").and_then(Json::as_str) != Some("send") {
+                continue;
+            }
+
+            let spending_txid = transaction
+                .get("txid")
+                .and_then(Json::as_str)
+                .expect("A valid txid must be present");
+            if visited_txs.contains(&spending_txid) || &spent_txid == spending_txid {
+                continue;
+            } else {
+                visited_txs.insert(spending_txid);
+            }
+
+            let gettx_res = self.make_wallet_request(
+                "gettransaction",
+                &params!(
+                    Json::String(spending_txid.to_string()),
+                    Json::Bool(true), // watchonly
+                    Json::Bool(true)  // verbose
+                ),
+            );
+            let vin = gettx_res
+                .get("decoded")
+                .and_then(|d| d.get("vin").and_then(Json::as_array))
+                .expect("A valid vin array must be present");
+
+            for input in vin {
+                let txid = input
+                    .get("txid")
+                    .and_then(Json::as_str)
+                    .and_then(|t| bitcoin::Txid::from_str(t).ok())
+                    .expect("A valid txid must be present");
+                let vout = input
+                    .get("vout")
+                    .and_then(Json::as_u64)
+                    .expect("A valid vout must be present") as u32;
+                let input_outpoint = bitcoin::OutPoint { txid, vout };
+
+                if spent_outpoint == &input_outpoint {
+                    return bitcoin::Txid::from_str(spending_txid)
+                        .map(Some)
+                        .expect("Must be a valid txid");
+                }
+            }
+        }
+
+        None
+    }
+}
 // Bitcoind uses a guess for the value of verificationprogress. It will eventually get to
 // be 1, and we want to be less conservative.
 fn roundup_progress(progress: f64) -> f64 {
@@ -533,5 +667,90 @@ fn roundup_progress(progress: f64) -> f64 {
         1.0
     } else {
         (progress_rounded as f64 / precision) as f64
+    }
+}
+
+/// A 'received' entry in the 'listsinceblock' result.
+#[derive(Debug, Clone, Copy)]
+pub struct LSBlockEntry {
+    pub outpoint: bitcoin::OutPoint,
+    pub amount: bitcoin::Amount,
+    pub block_height: Option<i32>,
+}
+
+impl From<&Json> for LSBlockEntry {
+    fn from(json: &Json) -> LSBlockEntry {
+        let txid = json
+            .get("txid")
+            .and_then(Json::as_str)
+            .and_then(|s| bitcoin::Txid::from_str(s).ok())
+            .expect("bitcoind can't give a bad block hash");
+        let vout = json
+            .get("vout")
+            .and_then(Json::as_u64)
+            .expect("bitcoind can't give a bad vout") as u32;
+        let outpoint = bitcoin::OutPoint { txid, vout };
+
+        // Must be a received entry, hence not negative.
+        let amount = json
+            .get("amount")
+            .and_then(Json::as_f64)
+            .and_then(|a| bitcoin::Amount::from_btc(a).ok())
+            .expect("bitcoind won't give us a bad amount");
+        let block_height = json
+            .get("blockheight")
+            .and_then(Json::as_i64)
+            .map(|bh| bh as i32);
+
+        LSBlockEntry {
+            outpoint,
+            amount,
+            block_height,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LSBlockRes {
+    pub received_coins: Vec<LSBlockEntry>,
+}
+
+impl From<Json> for LSBlockRes {
+    fn from(json: Json) -> LSBlockRes {
+        let received_coins = json
+            .get("transactions")
+            .and_then(Json::as_array)
+            .expect("Array must be present")
+            .into_iter()
+            .filter_map(|j| {
+                if j.get("category")
+                    .and_then(Json::as_str)
+                    .expect("must be present")
+                    == "receive"
+                {
+                    let lsb_entry: LSBlockEntry = j.into();
+                    Some(lsb_entry)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        LSBlockRes { received_coins }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct GetTxRes {
+    pub block_height: Option<i32>,
+}
+
+impl From<Json> for GetTxRes {
+    fn from(json: Json) -> GetTxRes {
+        let block_height = json
+            .get("blockheight")
+            .and_then(Json::as_i64)
+            .map(|bh| bh as i32);
+        GetTxRes { block_height }
     }
 }

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -79,11 +79,13 @@ impl BitcoinInterface for d::BitcoinD {
                     outpoint,
                     amount,
                     block_height,
+                    address,
                 } = entry;
                 UTxO {
                     outpoint,
                     amount,
                     block_height,
+                    address,
                 }
             })
             .collect()
@@ -168,9 +170,10 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
 
 // FIXME: We could avoid this type (and all the conversions entailing allocations) if bitcoind
 // exposed the derivation index from the parent descriptor in the LSB result.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct UTxO {
     pub outpoint: bitcoin::OutPoint,
     pub amount: bitcoin::Amount,
     pub block_height: Option<i32>,
+    pub address: bitcoin::Address,
 }

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -4,9 +4,11 @@
 pub mod d;
 pub mod poller;
 
+use d::LSBlockEntry;
+
 use std::sync;
 
-use miniscript::bitcoin;
+use miniscript::bitcoin::{self, hashes::Hash};
 
 /// Information about the best block in the chain
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
@@ -17,6 +19,8 @@ pub struct BlockChainTip {
 
 /// Our Bitcoin backend.
 pub trait BitcoinInterface: Send {
+    fn genesis_block(&self) -> BlockChainTip;
+
     /// Get the progress of the block chain synchronization.
     /// Returns a percentage between 0 and 1.
     fn sync_progress(&self) -> f64;
@@ -26,9 +30,29 @@ pub trait BitcoinInterface: Send {
 
     /// Check whether this former tip is part of the current best chain.
     fn is_in_chain(&self, tip: &BlockChainTip) -> bool;
+
+    /// Get coins received since the specified tip.
+    fn received_coins(&self, tip: &BlockChainTip) -> Vec<UTxO>;
+
+    /// Get all coins that were confirmed, and at what height.
+    fn confirmed_coins(&self, outpoints: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32)>;
+
+    /// Get all coins that were spent, and the spending txid.
+    fn spent_coins(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)>;
 }
 
 impl BitcoinInterface for d::BitcoinD {
+    fn genesis_block(&self) -> BlockChainTip {
+        let height = 0;
+        let hash = self
+            .get_block_hash(height)
+            .expect("Genesis block hash must always be there");
+        BlockChainTip { hash, height }
+    }
+
     fn sync_progress(&self) -> f64 {
         self.sync_progress()
     }
@@ -42,10 +66,78 @@ impl BitcoinInterface for d::BitcoinD {
             .map(|bh| bh == tip.hash)
             .unwrap_or(false)
     }
+
+    fn received_coins(&self, tip: &BlockChainTip) -> Vec<UTxO> {
+        // TODO: don't assume only a single descriptor is loaded on the wo wallet
+        let lsb_res = self.list_since_block(&tip.hash);
+
+        lsb_res
+            .received_coins
+            .into_iter()
+            .map(|entry| {
+                let LSBlockEntry {
+                    outpoint,
+                    amount,
+                    block_height,
+                } = entry;
+                UTxO {
+                    outpoint,
+                    amount,
+                    block_height,
+                }
+            })
+            .collect()
+    }
+
+    fn confirmed_coins(&self, outpoints: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32)> {
+        let mut confirmed = Vec::with_capacity(outpoints.len());
+
+        for op in outpoints {
+            // TODO: batch those calls to gettransaction
+            if let Some(res) = self.get_transaction(&op.txid) {
+                if let Some(h) = res.block_height {
+                    confirmed.push((*op, h));
+                }
+            } else {
+                log::error!("Transaction not in wallet for coin '{}'.", op);
+            }
+        }
+
+        confirmed
+    }
+
+    fn spent_coins(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {
+        let mut spent = Vec::with_capacity(outpoints.len());
+
+        for op in outpoints {
+            if self.is_spent(&op) {
+                let spending_txid = if let Some(txid) = self.get_spender_txid(&op) {
+                    txid
+                } else {
+                    // TODO: better handling of this edge case.
+                    log::error!(
+                        "Could not get spender of '{}'. Using a dummy spending txid.",
+                        op
+                    );
+                    bitcoin::Txid::from_slice(&[0; 32][..]).unwrap()
+                };
+                spent.push((*op, spending_txid));
+            }
+        }
+
+        spent
+    }
 }
 
 // FIXME: do we need to repeat the entire trait implemenation? Isn't there a nicer way?
 impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>> {
+    fn genesis_block(&self) -> BlockChainTip {
+        self.lock().unwrap().genesis_block()
+    }
+
     fn sync_progress(&self) -> f64 {
         self.lock().unwrap().sync_progress()
     }
@@ -57,4 +149,28 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
     fn is_in_chain(&self, tip: &BlockChainTip) -> bool {
         self.lock().unwrap().is_in_chain(tip)
     }
+
+    fn received_coins(&self, tip: &BlockChainTip) -> Vec<UTxO> {
+        self.lock().unwrap().received_coins(tip)
+    }
+
+    fn confirmed_coins(&self, outpoints: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32)> {
+        self.lock().unwrap().confirmed_coins(outpoints)
+    }
+
+    fn spent_coins(
+        &self,
+        outpoints: &[bitcoin::OutPoint],
+    ) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {
+        self.lock().unwrap().spent_coins(outpoints)
+    }
+}
+
+// FIXME: We could avoid this type (and all the conversions entailing allocations) if bitcoind
+// exposed the derivation index from the parent descriptor in the LSB result.
+#[derive(Debug, Clone, Copy)]
+pub struct UTxO {
+    pub outpoint: bitcoin::OutPoint,
+    pub amount: bitcoin::Amount,
+    pub block_height: Option<i32>,
 }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,6 +1,6 @@
 use crate::{
-    bitcoin::BitcoinInterface,
-    database::{DatabaseConnection, DatabaseInterface},
+    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
+    database::{Coin, DatabaseConnection, DatabaseInterface},
 };
 
 use std::{
@@ -8,32 +8,143 @@ use std::{
     thread, time,
 };
 
-fn update_tip(bit: &impl BitcoinInterface, db_conn: &mut Box<dyn DatabaseConnection>) {
+use miniscript::bitcoin::{self, util::bip32};
+
+#[derive(Debug, Clone)]
+struct UpdatedCoins {
+    pub received: Vec<Coin>,
+    pub confirmed: Vec<(bitcoin::OutPoint, i32)>,
+    pub spent: Vec<(bitcoin::OutPoint, bitcoin::Txid)>,
+}
+
+// Update the state of our coins. There may be new unspent, and existing ones may become confirmed
+// or spent.
+// NOTE: A coin may be updated multiple times at once. That is, a coin may be received, confirmed,
+// and spent in a single poll.
+fn update_coins(
+    bit: &impl BitcoinInterface,
+    db_conn: &mut Box<dyn DatabaseConnection>,
+    previous_tip: &BlockChainTip,
+) -> UpdatedCoins {
+    // Start by fetching newly received coins.
+    let curr_coins = db_conn.unspent_coins();
+    let mut received = Vec::new();
+    for utxo in bit.received_coins(&previous_tip) {
+        // FIXME: have a DB table to query those...
+        let derivation_index = bip32::ChildNumber::from(0);
+        // This works because the hash only takes the outpoint into account.
+        if !curr_coins.contains_key(&utxo.outpoint) {
+            let UTxO {
+                outpoint, amount, ..
+            } = utxo;
+            let coin = Coin {
+                outpoint,
+                amount,
+                derivation_index,
+                block_height: None,
+                spend_txid: None,
+            };
+            received.push(coin);
+        }
+    }
+
+    // We need to take the newly received ones into account as well, as they may have been
+    // confirmed within the previous tip and the current one, and we may not poll this chunk of the
+    // chain anymore.
+    let to_be_confirmed: Vec<bitcoin::OutPoint> = curr_coins
+        .values()
+        .chain(received.iter())
+        .filter_map(|coin| {
+            if coin.block_height.is_none() {
+                Some(coin.outpoint)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let confirmed = bit.confirmed_coins(&to_be_confirmed);
+
+    // We need to take the newly received ones into account as well, as they may have been
+    // spent within the previous tip and the current one, and we may not poll this chunk of the
+    // chain anymore.
+    let to_be_spent: Vec<bitcoin::OutPoint> = curr_coins
+        .values()
+        .chain(received.iter())
+        .filter_map(|coin| {
+            if coin.spend_txid.is_none() {
+                Some(coin.outpoint)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let spent = bit.spent_coins(&to_be_spent);
+
+    UpdatedCoins {
+        received,
+        confirmed,
+        spent,
+    }
+}
+
+// Returns the new block chain tip, if it changed.
+fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> Option<BlockChainTip> {
     let bitcoin_tip = bit.chain_tip();
 
-    let current_tip = match db_conn.chain_tip() {
-        Some(tip) => tip,
-        None => {
-            db_conn.update_tip(&bitcoin_tip);
-            return;
-        }
-    };
-
     // If the tip didn't change, there is nothing to update.
-    if current_tip == bitcoin_tip {
-        return;
+    if current_tip == &bitcoin_tip {
+        return None;
     }
 
     if bitcoin_tip.height > current_tip.height {
         // Make sure we are on the same chain.
         if bit.is_in_chain(&current_tip) {
-            // All good, we just moved forward. Record the new tip.
-            db_conn.update_tip(&bitcoin_tip);
-            return;
+            // All good, we just moved forward.
+            return Some(bitcoin_tip);
         }
     }
 
     // TODO: reorg handling.
+    None
+}
+
+fn updates(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
+    let mut db_conn = db.connection();
+
+    // Check if there was a new block before updating ourselves.
+    let current_tip = db_conn.chain_tip().expect("Always set at first startup");
+    let new_tip = new_tip(bit, &current_tip);
+    let latest_tip = new_tip.unwrap_or(current_tip);
+
+    // Then check the state of our coins. Do it even if the tip did not change since last poll, as
+    // we may have unconfirmed transactions.
+    let updated_coins = update_coins(bit, &mut db_conn, &current_tip);
+
+    // If the tip changed while we were polling our Bitcoin interface, start over.
+    if bit.chain_tip() != latest_tip {
+        log::info!("Chain tip changed while we were updating our state. Starting over.");
+        return updates(bit, db);
+    }
+
+    // The chain tip did not change since we started our updates. Record them and the latest tip.
+    // Having the tip in database means that, as far as the chain is concerned, we've got all
+    // updates up to this block. But not more.
+    db_conn.new_unspent_coins(&updated_coins.received);
+    db_conn.confirm_coins(&updated_coins.confirmed);
+    db_conn.spend_coins(&updated_coins.spent);
+    if let Some(tip) = new_tip {
+        db_conn.update_tip(&tip);
+    }
+}
+
+// If the database chain tip is NULL (first startup), initialize it.
+fn maybe_initialize_tip(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
+    let mut db_conn = db.connection();
+
+    if db_conn.chain_tip().is_none() {
+        // TODO: be smarter. We can use the timestamp of the descriptor to get a newer block hash.
+        db_conn.update_tip(&bit.genesis_block());
+    }
 }
 
 /// Main event loop. Repeatedly polls the Bitcoin interface until told to stop through the
@@ -46,6 +157,8 @@ pub fn looper(
 ) {
     let mut last_poll = None;
     let mut synced = false;
+
+    maybe_initialize_tip(&bit, &db);
 
     while !shutdown.load(atomic::Ordering::Relaxed) || last_poll.is_none() {
         let now = time::Instant::now();
@@ -75,7 +188,6 @@ pub fn looper(
             }
         }
 
-        let mut db_conn = db.connection();
-        update_tip(&bit, &mut db_conn);
+        updates(&bit, &db);
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,7 +31,7 @@ impl DaemonControl {
         let mut db_conn = self.db.connection();
         let index = db_conn.derivation_index();
         // TODO: handle should we wrap around instead of failing?
-        db_conn.update_derivation_index(index.increment().expect("TODO: handle wraparound"));
+        db_conn.increment_derivation_index(&self.secp);
         let address = self
             .config
             .main_descriptor

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,0 +1,16 @@
+use miniscript::bitcoin;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize an amount as sats
+pub fn ser_amount<S: Serializer>(amount: &bitcoin::Amount, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_u64(amount.as_sat())
+}
+
+/// Deserialize an amount from sats
+pub fn deser_amount_from_sats<'de, D>(deserializer: D) -> Result<bitcoin::Amount, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let a = u64::deserialize(deserializer)?;
+    Ok(bitcoin::Amount::from_sat(a))
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -5,12 +5,15 @@ pub mod sqlite;
 
 use crate::{
     bitcoin::BlockChainTip,
-    database::sqlite::{schema::DbTip, SqliteConn, SqliteDb},
+    database::sqlite::{
+        schema::{DbCoin, DbTip},
+        SqliteConn, SqliteDb,
+    },
 };
 
-use std::sync;
+use std::{collections::HashMap, sync};
 
-use miniscript::bitcoin::util::bip32;
+use miniscript::bitcoin::{self, util::bip32};
 
 pub trait DatabaseInterface: Send {
     fn connection(&self) -> Box<dyn DatabaseConnection>;
@@ -33,12 +36,27 @@ pub trait DatabaseConnection {
     /// Get the tip of the best chain we've seen.
     fn chain_tip(&mut self) -> Option<BlockChainTip>;
 
+    /// The network we are operating on.
+    fn network(&mut self) -> bitcoin::Network;
+
     /// Update our best chain seen.
     fn update_tip(&mut self, tip: &BlockChainTip);
 
     fn derivation_index(&mut self) -> bip32::ChildNumber;
 
     fn update_derivation_index(&mut self, index: bip32::ChildNumber);
+
+    /// Get all UTxOs.
+    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
+
+    /// Store new UTxOs. Coins must not already be in database.
+    fn new_unspent_coins<'a>(&mut self, coins: &[Coin]);
+
+    /// Mark a set of coins as being confirmed at a specified height.
+    fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32)]);
+
+    /// Mark a set of coins as being spent by a specified txid.
+    fn spend_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]);
 }
 
 impl DatabaseConnection for SqliteConn {
@@ -53,6 +71,10 @@ impl DatabaseConnection for SqliteConn {
         }
     }
 
+    fn network(&mut self) -> bitcoin::Network {
+        self.db_tip().network
+    }
+
     fn update_tip(&mut self, tip: &BlockChainTip) {
         self.update_tip(&tip)
     }
@@ -63,5 +85,69 @@ impl DatabaseConnection for SqliteConn {
 
     fn update_derivation_index(&mut self, index: bip32::ChildNumber) {
         self.update_derivation_index(index)
+    }
+
+    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
+        // FIXME: if possible, avoid reallocating.
+        self.unspent_coins()
+            .into_iter()
+            .map(|db_coin| {
+                let DbCoin {
+                    outpoint,
+                    block_height,
+                    amount,
+                    derivation_index,
+                    spend_txid,
+                    ..
+                } = db_coin;
+                (
+                    outpoint,
+                    Coin {
+                        outpoint,
+                        block_height,
+                        amount,
+                        derivation_index,
+                        spend_txid,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn new_unspent_coins<'a>(&mut self, coins: &[Coin]) {
+        self.new_unspent_coins(coins)
+    }
+
+    fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32)]) {
+        self.confirm_coins(outpoints)
+    }
+
+    fn spend_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]) {
+        self.spend_coins(outpoints)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Coin {
+    pub outpoint: bitcoin::OutPoint,
+    pub block_height: Option<i32>,
+    pub amount: bitcoin::Amount,
+    pub derivation_index: bip32::ChildNumber,
+    pub spend_txid: Option<bitcoin::Txid>,
+}
+
+impl std::hash::Hash for Coin {
+    fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
+        self.outpoint.hash(h)
+    }
+}
+
+impl Coin {
+    pub fn is_confirmed(&self) -> bool {
+        self.block_height.is_some()
+    }
+
+    pub fn is_spent(&self) -> bool {
+        self.spend_txid.is_some()
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use std::{collections::HashMap, sync};
 
-use miniscript::bitcoin::{self, util::bip32};
+use miniscript::bitcoin::{self, secp256k1, util::bip32};
 
 pub trait DatabaseInterface: Send {
     fn connection(&self) -> Box<dyn DatabaseConnection>;
@@ -44,7 +44,7 @@ pub trait DatabaseConnection {
 
     fn derivation_index(&mut self) -> bip32::ChildNumber;
 
-    fn update_derivation_index(&mut self, index: bip32::ChildNumber);
+    fn increment_derivation_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
 
     /// Get all UTxOs.
     fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
@@ -83,8 +83,8 @@ impl DatabaseConnection for SqliteConn {
         self.db_wallet().deposit_derivation_index
     }
 
-    fn update_derivation_index(&mut self, index: bip32::ChildNumber) {
-        self.update_derivation_index(index)
+    fn increment_derivation_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
+        self.increment_derivation_index(secp)
     }
 
     fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -46,6 +46,11 @@ pub trait DatabaseConnection {
 
     fn increment_derivation_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
 
+    fn derivation_index_by_address(
+        &mut self,
+        address: &bitcoin::Address,
+    ) -> Option<bip32::ChildNumber>;
+
     /// Get all UTxOs.
     fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
 
@@ -124,6 +129,14 @@ impl DatabaseConnection for SqliteConn {
 
     fn spend_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]) {
         self.spend_coins(outpoints)
+    }
+
+    fn derivation_index_by_address(
+        &mut self,
+        address: &bitcoin::Address,
+    ) -> Option<bip32::ChildNumber> {
+        self.db_address(address)
+            .map(|db_addr| db_addr.derivation_index)
     }
 }
 

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -1,9 +1,8 @@
+use crate::descriptors::InheritanceDescriptor;
+
 use std::{convert::TryFrom, str::FromStr};
 
-use miniscript::{
-    bitcoin::{self, consensus::encode, util::bip32},
-    Descriptor, DescriptorPublicKey,
-};
+use miniscript::bitcoin::{self, consensus::encode, util::bip32};
 
 pub const SCHEMA: &str = "\
 CREATE TABLE version (
@@ -86,7 +85,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbTip {
 pub struct DbWallet {
     pub id: i64,
     pub timestamp: u32,
-    pub main_descriptor: Descriptor<DescriptorPublicKey>,
+    pub main_descriptor: InheritanceDescriptor,
     pub deposit_derivation_index: bip32::ChildNumber,
 }
 
@@ -98,7 +97,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
         let timestamp = row.get(1)?;
 
         let desc_str: String = row.get(2)?;
-        let main_descriptor = Descriptor::<DescriptorPublicKey>::from_str(&desc_str)
+        let main_descriptor = InheritanceDescriptor::from_str(&desc_str)
             .expect("Insane database: can't parse deposit descriptor");
 
         let der_idx: u32 = row.get(3)?;

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -2,7 +2,7 @@ use crate::database::sqlite::{schema::SCHEMA, FreshDbOptions, SqliteDbError, DB_
 
 use std::{convert::TryInto, fs, path, time};
 
-use miniscript::{bitcoin::secp256k1, DescriptorTrait, TranslatePk2};
+use miniscript::bitcoin::secp256k1;
 
 pub const LOOK_AHEAD_LIMIT: u32 = 200;
 
@@ -106,11 +106,8 @@ pub fn create_fresh_db(
         // TODO: have this as a helper in descriptors.rs
         let address = options
             .main_descriptor
-            .derive(index)
-            .translate_pk2(|xpk| xpk.derive_public_key(secp))
-            .expect("All pubkeys were derived, no wildcard.")
-            .address(options.bitcoind_network)
-            .expect("Always a P2WSH address");
+            .derive(index.into(), secp)
+            .address(options.bitcoind_network);
         query += &format!(
             "INSERT INTO addresses (address, derivation_index) VALUES (\"{}\", {});\n",
             address, index

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -2,23 +2,27 @@ use miniscript::{
     descriptor,
     miniscript::{
         decode::Terminal,
+        iter::PkPkh,
         limits::{SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG},
         Miniscript,
     },
+    policy::{Liftable, Semantic as SemanticPolicy},
     ScriptContext,
 };
 
-use std::{error, fmt, sync};
+use std::{error, fmt, str, sync};
 
 // Flag applied to the nSequence and CSV value before comparing them.
 //
 // <https://github.com/bitcoin/bitcoin/blob/4a540683ec40393d6369da1a9e02e45614db936d/src/primitives/transaction.h#L87-L89>
 pub const SEQUENCE_LOCKTIME_MASK: u32 = 0x00_00_ff_ff;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum DescCreationError {
     InsaneTimelock(u32),
     InvalidKey(descriptor::DescriptorPublicKey),
+    Miniscript(miniscript::Error),
+    IncompatibleDesc,
 }
 
 impl std::fmt::Display for DescCreationError {
@@ -28,6 +32,8 @@ impl std::fmt::Display for DescCreationError {
             Self::InvalidKey(key) => {
                 write!(f, "Invalid key '{}'. Need a wildcard ('ranged') xpub", key)
             }
+            Self::Miniscript(e) => write!(f, "Miniscript error: '{}'.", e),
+            Self::IncompatibleDesc => write!(f, "Descriptor is not compatible."),
         }
     }
 }
@@ -38,10 +44,15 @@ impl error::Error for DescCreationError {}
 //  - not be disabled
 //  - be in number of blocks
 //  - be 'clean' / minimal, ie all bits without consensus meaning should be 0
-fn csv_check(csv: u32) -> bool {
-    (csv & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 0
+fn csv_check(csv: u32) -> Result<(), DescCreationError> {
+    if (csv & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 0
         && (csv & SEQUENCE_LOCKTIME_TYPE_FLAG) == 0
         && (csv & SEQUENCE_LOCKTIME_MASK) == csv
+    {
+        Ok(())
+    } else {
+        Err(DescCreationError::InsaneTimelock(csv))
+    }
 }
 
 fn is_unhardened_deriv(key: &descriptor::DescriptorPublicKey) -> bool {
@@ -53,52 +64,138 @@ fn is_unhardened_deriv(key: &descriptor::DescriptorPublicKey) -> bool {
     }
 }
 
-/// Create a Miniscript descriptor with a main, unencombered, branch (the main owner of the coins)
+/// A Miniscript descriptor with a main, unencombered, branch (the main owner of the coins)
 /// and a timelocked branch (the heir).
-pub fn inheritance_descriptor(
-    owner_key: descriptor::DescriptorPublicKey,
-    heir_key: descriptor::DescriptorPublicKey,
-    timelock: u32,
-) -> Result<descriptor::Descriptor<descriptor::DescriptorPublicKey>, DescCreationError> {
-    if !csv_check(timelock) {
-        return Err(DescCreationError::InsaneTimelock(timelock));
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InheritanceDescriptor(descriptor::Descriptor<descriptor::DescriptorPublicKey>);
+
+impl fmt::Display for InheritanceDescriptor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
+}
 
-    if let Some(key) = vec![&owner_key, &heir_key]
-        .iter()
-        .find(|k| !is_unhardened_deriv(k))
-    {
-        return Err(DescCreationError::InvalidKey((**key).clone()));
+impl str::FromStr for InheritanceDescriptor {
+    type Err = DescCreationError;
+
+    fn from_str(s: &str) -> Result<InheritanceDescriptor, Self::Err> {
+        let wsh_desc = descriptor::Wsh::<descriptor::DescriptorPublicKey>::from_str(s)
+            .map_err(DescCreationError::Miniscript)?;
+        let ms = match wsh_desc.as_inner() {
+            descriptor::WshInner::Ms(ms) => ms,
+            _ => return Err(DescCreationError::IncompatibleDesc),
+        };
+        let invalid_key = ms.iter_pk_pkh().find_map(|pk_pkh| {
+            let pk = match pk_pkh {
+                PkPkh::PlainPubkey(pk) => pk,
+                PkPkh::HashedPubkey(pk) => pk,
+            };
+            if is_unhardened_deriv(&pk) {
+                None
+            } else {
+                Some(pk)
+            }
+        });
+        if let Some(key) = invalid_key {
+            return Err(DescCreationError::InvalidKey(key));
+        }
+
+        // Semantic of the Miniscript must be either the owner now, or the heir after
+        // a timelock.
+        let policy = ms
+            .lift()
+            .expect("Lifting can't fail on a Miniscript")
+            .normalized();
+        let subs = match policy {
+            SemanticPolicy::Threshold(1, subs) => Some(subs),
+            _ => None,
+        }
+        .ok_or(DescCreationError::IncompatibleDesc)?;
+        if subs.len() != 2 {
+            return Err(DescCreationError::IncompatibleDesc);
+        }
+
+        // Owner branch
+        subs.iter()
+            .find(|s| matches!(s, SemanticPolicy::KeyHash(_)))
+            .ok_or(DescCreationError::IncompatibleDesc)?;
+
+        // Heir branch
+        let heir_subs = subs
+            .iter()
+            .find_map(|s| match s {
+                SemanticPolicy::Threshold(2, subs) => Some(subs),
+                _ => None,
+            })
+            .ok_or(DescCreationError::IncompatibleDesc)?;
+        if heir_subs.len() != 2 {
+            return Err(DescCreationError::IncompatibleDesc);
+        }
+        // Must be timelocked
+        let csv = heir_subs
+            .iter()
+            .find_map(|s| match s {
+                SemanticPolicy::Older(csv) => Some(csv),
+                _ => None,
+            })
+            .ok_or(DescCreationError::IncompatibleDesc)?;
+        csv_check(*csv)?;
+        // And key locked
+        heir_subs
+            .iter()
+            .find(|s| matches!(s, SemanticPolicy::KeyHash(_)))
+            .ok_or(DescCreationError::IncompatibleDesc)?;
+
+        Ok(InheritanceDescriptor(descriptor::Descriptor::Wsh(wsh_desc)))
     }
+}
 
-    let owner_pk = Miniscript::from_ast(Terminal::Check(sync::Arc::from(
-        Miniscript::from_ast(Terminal::PkK(owner_key)).expect("TODO"),
-    )))
-    .expect("Well typed");
+impl InheritanceDescriptor {
+    pub fn new(
+        owner_key: descriptor::DescriptorPublicKey,
+        heir_key: descriptor::DescriptorPublicKey,
+        timelock: u32,
+    ) -> Result<descriptor::Descriptor<descriptor::DescriptorPublicKey>, DescCreationError> {
+        csv_check(timelock)?;
 
-    let heir_pkh = Miniscript::from_ast(Terminal::Check(sync::Arc::from(
-        Miniscript::from_ast(Terminal::PkH(heir_key)).expect("TODO"),
-    )))
-    .expect("Well typed");
+        if let Some(key) = vec![&owner_key, &heir_key]
+            .iter()
+            .find(|k| !is_unhardened_deriv(k))
+        {
+            return Err(DescCreationError::InvalidKey((**key).clone()));
+        }
 
-    let heir_timelock = Terminal::Older(timelock);
-    let heir_branch = Miniscript::from_ast(Terminal::AndV(
-        Miniscript::from_ast(Terminal::Verify(heir_pkh.into()))
-            .expect("Well typed")
-            .into(),
-        Miniscript::from_ast(heir_timelock)
-            .expect("Well typed")
-            .into(),
-    ))
-    .expect("Well typed");
-
-    let tl_miniscript = Miniscript::from_ast(Terminal::OrD(owner_pk.into(), heir_branch.into()))
+        let owner_pk = Miniscript::from_ast(Terminal::Check(sync::Arc::from(
+            Miniscript::from_ast(Terminal::PkK(owner_key)).expect("TODO"),
+        )))
         .expect("Well typed");
-    miniscript::Segwitv0::check_local_validity(&tl_miniscript).expect("Miniscript must be sane");
 
-    Ok(descriptor::Descriptor::Wsh(
-        descriptor::Wsh::new(tl_miniscript).expect("Must pass sanity checks"),
-    ))
+        let heir_pkh = Miniscript::from_ast(Terminal::Check(sync::Arc::from(
+            Miniscript::from_ast(Terminal::PkH(heir_key)).expect("TODO"),
+        )))
+        .expect("Well typed");
+
+        let heir_timelock = Terminal::Older(timelock);
+        let heir_branch = Miniscript::from_ast(Terminal::AndV(
+            Miniscript::from_ast(Terminal::Verify(heir_pkh.into()))
+                .expect("Well typed")
+                .into(),
+            Miniscript::from_ast(heir_timelock)
+                .expect("Well typed")
+                .into(),
+        ))
+        .expect("Well typed");
+
+        let tl_miniscript =
+            Miniscript::from_ast(Terminal::OrD(owner_pk.into(), heir_branch.into()))
+                .expect("Well typed");
+        miniscript::Segwitv0::check_local_validity(&tl_miniscript)
+            .expect("Miniscript must be sane");
+
+        Ok(descriptor::Descriptor::Wsh(
+            descriptor::Wsh::new(tl_miniscript).expect("Must pass sanity checks"),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -112,27 +209,27 @@ mod tests {
         let owner_key = descriptor::DescriptorPublicKey::from_str(&"xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/*").unwrap();
         let heir_key = descriptor::DescriptorPublicKey::from_str(&"xpub688Hn4wScQAAiYJLPg9yH27hUpfZAUnmJejRQBCiwfP5PEDzjWMNW1wChcninxr5gyavFqbbDjdV1aK5USJz8NDVjUy7FRQaaqqXHh5SbXe/*").unwrap();
         let timelock = 52560;
-        assert_eq!(inheritance_descriptor(owner_key.clone(), heir_key.clone(), timelock).unwrap().to_string(), "wsh(or_d(pk(xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/*),and_v(v:pkh(xpub688Hn4wScQAAiYJLPg9yH27hUpfZAUnmJejRQBCiwfP5PEDzjWMNW1wChcninxr5gyavFqbbDjdV1aK5USJz8NDVjUy7FRQaaqqXHh5SbXe/*),older(52560))))#eeyujkt7");
+        assert_eq!(InheritanceDescriptor::new(owner_key.clone(), heir_key.clone(), timelock).unwrap().to_string(), "wsh(or_d(pk(xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/*),and_v(v:pkh(xpub688Hn4wScQAAiYJLPg9yH27hUpfZAUnmJejRQBCiwfP5PEDzjWMNW1wChcninxr5gyavFqbbDjdV1aK5USJz8NDVjUy7FRQaaqqXHh5SbXe/*),older(52560))))#eeyujkt7");
 
         // We prevent footguns with timelocks
-        inheritance_descriptor(owner_key.clone(), heir_key.clone(), 0x00_01_0f_00).unwrap_err();
-        inheritance_descriptor(owner_key.clone(), heir_key.clone(), (1 << 31) + 1).unwrap_err();
-        inheritance_descriptor(owner_key.clone(), heir_key.clone(), (1 << 22) + 1).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key.clone(), 0x00_01_0f_00).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key.clone(), (1 << 31) + 1).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key.clone(), (1 << 22) + 1).unwrap_err();
 
         let owner_key = descriptor::DescriptorPublicKey::from_str(&"[aabb0011/10/4893]xpub661MyMwAqRbcFG59fiikD8UV762quhruT8K8bdjqy6N2o3LG7yohoCdLg1m2HAY1W6rfBrtauHkBhbfA4AQ3iazaJj5wVPhwgaRCHBW2DBg/*").unwrap();
         let heir_key = descriptor::DescriptorPublicKey::from_str(&"xpub661MyMwAqRbcFfxf71L4Dx4w5TmyNXrBicTEAM7vLzumxangwATWWgdJPb6xH1JHcJH9S3jNZx3fCnkkB1WyqrqGgavj1rehHcbythmruvZ/24/32/*").unwrap();
         let timelock = 57600;
-        assert_eq!(inheritance_descriptor(owner_key.clone(), heir_key, timelock).unwrap().to_string(), "wsh(or_d(pk([aabb0011/10/4893]xpub661MyMwAqRbcFG59fiikD8UV762quhruT8K8bdjqy6N2o3LG7yohoCdLg1m2HAY1W6rfBrtauHkBhbfA4AQ3iazaJj5wVPhwgaRCHBW2DBg/*),and_v(v:pkh(xpub661MyMwAqRbcFfxf71L4Dx4w5TmyNXrBicTEAM7vLzumxangwATWWgdJPb6xH1JHcJH9S3jNZx3fCnkkB1WyqrqGgavj1rehHcbythmruvZ/24/32/*),older(57600))))#8kamh6y8");
+        assert_eq!(InheritanceDescriptor::new(owner_key.clone(), heir_key, timelock).unwrap().to_string(), "wsh(or_d(pk([aabb0011/10/4893]xpub661MyMwAqRbcFG59fiikD8UV762quhruT8K8bdjqy6N2o3LG7yohoCdLg1m2HAY1W6rfBrtauHkBhbfA4AQ3iazaJj5wVPhwgaRCHBW2DBg/*),and_v(v:pkh(xpub661MyMwAqRbcFfxf71L4Dx4w5TmyNXrBicTEAM7vLzumxangwATWWgdJPb6xH1JHcJH9S3jNZx3fCnkkB1WyqrqGgavj1rehHcbythmruvZ/24/32/*),older(57600))))#8kamh6y8");
 
         // We can't pass a raw key, an xpub that is not deriveable, or only hardened derivable
         let heir_key = descriptor::DescriptorPublicKey::from_str(&"xpub661MyMwAqRbcFfxf71L4Dx4w5TmyNXrBicTEAM7vLzumxangwATWWgdJPb6xH1JHcJH9S3jNZx3fCnkkB1WyqrqGgavj1rehHcbythmruvZ/0/354").unwrap();
-        inheritance_descriptor(owner_key.clone(), heir_key, timelock).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key, timelock).unwrap_err();
         let heir_key = descriptor::DescriptorPublicKey::from_str(&"xpub661MyMwAqRbcFfxf71L4Dx4w5TmyNXrBicTEAM7vLzumxangwATWWgdJPb6xH1JHcJH9S3jNZx3fCnkkB1WyqrqGgavj1rehHcbythmruvZ/0/*'").unwrap();
-        inheritance_descriptor(owner_key.clone(), heir_key, timelock).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key, timelock).unwrap_err();
         let heir_key = descriptor::DescriptorPublicKey::from_str(
             &"02e24913be26dbcfdf8e8e94870b28725cdae09b448b6c127767bf0154e3a3c8e5",
         )
         .unwrap();
-        inheritance_descriptor(owner_key.clone(), heir_key, timelock).unwrap_err();
+        InheritanceDescriptor::new(owner_key.clone(), heir_key, timelock).unwrap_err();
     }
 }

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -8,6 +8,7 @@ pub fn handle_request(control: &DaemonControl, req: Request) -> Result<Response,
     let result = match req.method.as_str() {
         "getinfo" => serde_json::json!(&control.get_info()),
         "getnewaddress" => serde_json::json!(&control.get_new_address()),
+        "listcoins" => serde_json::json!(&control.list_coins()),
         "stop" => serde_json::json!({}),
         _ => {
             return Err(Error::method_not_found());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,10 +377,11 @@ mod tests {
     use super::*;
     use crate::{
         config::{BitcoinConfig, BitcoindConfig},
+        descriptors::InheritanceDescriptor,
         testutils::*,
     };
 
-    use miniscript::{bitcoin, Descriptor, DescriptorPublicKey};
+    use miniscript::bitcoin;
     use std::{
         fs,
         io::{BufRead, BufReader, Write},
@@ -588,7 +589,7 @@ mod tests {
 
         // Create a dummy config with this bitcoind
         let desc_str = "wsh(andor(pk(xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/*),older(10000),pk(xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/*)))#tk6wzexy";
-        let desc = Descriptor::<DescriptorPublicKey>::from_str(desc_str).unwrap();
+        let desc = InheritanceDescriptor::from_str(desc_str).unwrap();
         let config = Config {
             bitcoin_config,
             bitcoind_config: Some(bitcoind_config),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,18 @@ mod tests {
         stream.flush().unwrap();
     }
 
+    // Send them a response to 'getblockhash' with the genesis block hash
+    fn complete_tip_init<'a>(server: &net::TcpListener) {
+        let net_resp = [
+            "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f\"}\n".as_bytes(),
+        ]
+        .concat();
+        let (mut stream, _) = server.accept().unwrap();
+        read_til_json_end(&mut stream);
+        stream.write_all(&net_resp).unwrap();
+        stream.flush().unwrap();
+    }
+
     // Send them a response to 'getblockchaininfo' saying we are far from being synced
     fn complete_sync_check<'a>(server: &net::TcpListener) {
         let net_resp = [
@@ -598,6 +610,7 @@ mod tests {
         complete_network_check(&server);
         complete_wallet_check(&server, &wo_path);
         complete_desc_check(&server, desc_str);
+        complete_tip_init(&server);
         complete_sync_check(&server);
         daemon_thread.join().unwrap();
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -177,7 +177,7 @@ impl DummyMinisafe {
 
         let owner_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/*").unwrap();
         let heir_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/*").unwrap();
-        let desc = crate::descriptors::inheritance_descriptor(owner_key, heir_key, 10_000).unwrap();
+        let desc = crate::descriptors::InheritanceDescriptor::new(owner_key, heir_key, 10_000).unwrap();
         let config = Config {
             bitcoin_config,
             bitcoind_config: None,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -8,7 +8,7 @@ use crate::{
 use std::{collections::HashMap, env, fs, io, path, process, str::FromStr, sync, thread, time};
 
 use miniscript::{
-    bitcoin::{self, util::bip32},
+    bitcoin::{self, secp256k1, util::bip32},
     descriptor,
 };
 
@@ -97,8 +97,9 @@ impl DatabaseConnection for DummyDbConn {
         self.db.read().unwrap().curr_index
     }
 
-    fn update_derivation_index(&mut self, index: bip32::ChildNumber) {
-        self.db.write().unwrap().curr_index = index;
+    fn increment_derivation_index(&mut self, _: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
+        let next_index = self.db.write().unwrap().curr_index.increment().unwrap();
+        self.db.write().unwrap().curr_index = next_index;
     }
 
     fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -177,7 +177,8 @@ impl DummyMinisafe {
 
         let owner_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/*").unwrap();
         let heir_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/*").unwrap();
-        let desc = crate::descriptors::InheritanceDescriptor::new(owner_key, heir_key, 10_000).unwrap();
+        let desc =
+            crate::descriptors::InheritanceDescriptor::new(owner_key, heir_key, 10_000).unwrap();
         let config = Config {
             bitcoin_config,
             bitcoind_config: None,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -133,6 +133,10 @@ impl DatabaseConnection for DummyDbConn {
             *spender = Some(*spend_txid);
         }
     }
+
+    fn derivation_index_by_address(&mut self, _: &bitcoin::Address) -> Option<bip32::ChildNumber> {
+        None
+    }
 }
 
 pub struct DummyMinisafe {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip},
+    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
     config::{BitcoinConfig, Config},
     database::{Coin, DatabaseConnection, DatabaseInterface},
     DaemonHandle,
@@ -15,6 +15,14 @@ use miniscript::{
 pub struct DummyBitcoind {}
 
 impl BitcoinInterface for DummyBitcoind {
+    fn genesis_block(&self) -> BlockChainTip {
+        let hash = bitcoin::BlockHash::from_str(
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        )
+        .unwrap();
+        BlockChainTip { hash, height: 0 }
+    }
+
     fn sync_progress(&self) -> f64 {
         1.0
     }
@@ -31,6 +39,18 @@ impl BitcoinInterface for DummyBitcoind {
     fn is_in_chain(&self, _: &BlockChainTip) -> bool {
         // No reorg
         true
+    }
+
+    fn received_coins(&self, _: &BlockChainTip) -> Vec<UTxO> {
+        Vec::new()
+    }
+
+    fn confirmed_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32)> {
+        Vec::new()
+    }
+
+    fn spent_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {
+        Vec::new()
     }
 }
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -117,7 +117,7 @@ def minisafed(bitcoind, directory):
     os.makedirs(datadir, exist_ok=True)
     bitcoind_cookie = os.path.join(bitcoind.bitcoin_dir, "regtest", ".cookie")
 
-    main_desc = "wsh(or_d(pk(tpubD9vQiBdDxYzU1V5D5UUmMTXF9FZC13PuQDs4aiv6rF7UCKQFvtVKZguYakX12C2bt8736ksioxu9Y9Nmp18gj4jDeNJEEqrBPEZXAxe5YcQ/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/*),older(157680))))"
+    main_desc = "wsh(or_d(pk(tpubD9vQiBdDxYzU1V5D5UUmMTXF9FZC13PuQDs4aiv6rF7UCKQFvtVKZguYakX12C2bt8736ksioxu9Y9Nmp18gj4jDeNJEEqrBPEZXAxe5YcQ/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/*),older(65000))))"
 
     minisafed = Minisafed(
         datadir,

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,4 +1,5 @@
 from fixtures import *
+from test_framework.utils import wait_for, COIN
 
 
 def test_getinfo(minisafed):
@@ -15,3 +16,27 @@ def test_getaddress(minisafed):
     assert "address" in res
     # We'll get a new one at every call
     assert res["address"] != minisafed.rpc.getnewaddress()["address"]
+
+
+def test_listcoins(minisafed, bitcoind):
+    # Initially empty
+    res = minisafed.rpc.listcoins()
+    assert "coins" in res
+    assert len(res["coins"]) == 0
+
+    # If we send a coin, we'll get a new entry. Note we monitor for unconfirmed
+    # funds as well.
+    addr = minisafed.rpc.getnewaddress()["address"]
+    txid = bitcoind.rpc.sendtoaddress(addr, 1)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 1)
+    res = minisafed.rpc.listcoins()["coins"]
+    assert txid == res[0]["outpoint"][:64]
+    assert res[0]["amount"] == 1 * COIN
+    assert res[0]["block_height"] is None
+
+    # If the coin gets confirmed, it'll be marked as such.
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    block_height = bitcoind.rpc.getblockcount()
+    wait_for(
+        lambda: minisafed.rpc.listcoins()["coins"][0]["block_height"] == block_height
+    )


### PR DESCRIPTION
This introduces types for our inheritance descriptor. This is taken and adapted from revaultd, where it turned out to be very helpful.

This also adds a helper to query the timelock of the heir's spending path in the inheritance descriptor for downstream users to be able to compute the expiration block of each coin.

This is based on #13.