### PR TITLE
Check spend status in bitcoin poller

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -767,8 +767,7 @@ impl From<Json> for GetTxRes {
             .map(|bt| bt as u32);
         let conflicting_txs = json
             .get("walletconflicts")
-            .map(|v| Json::as_array(&v))
-            .flatten()
+            .and_then(Json::as_array)
             .map(|array| {
                 array
                     .into_iter()

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -751,6 +751,7 @@ impl From<Json> for LSBlockRes {
 #[derive(Debug, Clone, Copy)]
 pub struct GetTxRes {
     pub block_height: Option<i32>,
+    pub block_time: Option<u32>,
 }
 
 impl From<Json> for GetTxRes {
@@ -759,6 +760,13 @@ impl From<Json> for GetTxRes {
             .get("blockheight")
             .and_then(Json::as_i64)
             .map(|bh| bh as i32);
-        GetTxRes { block_height }
+        let block_time = json
+            .get("blocktime")
+            .and_then(Json::as_u64)
+            .map(|bt| bt as u32);
+        GetTxRes {
+            block_height,
+            block_time,
+        }
     }
 }

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -171,10 +171,10 @@ impl BitcoinInterface for d::BitcoinD {
             let mut txs_to_cache: Vec<(bitcoin::Txid, Option<d::GetTxRes>)> = Vec::new();
 
             if let Some(tx) = tx {
-                if let Some(block_height) = tx.block_height {
-                    if block_height > 1 {
-                        spent.push((*op, *txid, tx.block_time.expect("Spend is confirmed")))
-                    }
+                if let Some(block_time) = tx.block_time {
+                    // TODO: make both block time and height under the same Option.
+                    assert!(tx.block_height.is_some());
+                    spent.push((*op, *txid, block_time))
                 } else if !tx.conflicting_txs.is_empty() {
                     for txid in tx.conflicting_txs.clone() {
                         let tx: Option<&d::GetTxRes> = match cache.get(&txid) {

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -176,12 +176,12 @@ impl BitcoinInterface for d::BitcoinD {
                     assert!(tx.block_height.is_some());
                     spent.push((*op, *txid, block_time))
                 } else if !tx.conflicting_txs.is_empty() {
-                    for txid in tx.conflicting_txs.clone() {
-                        let tx: Option<&d::GetTxRes> = match cache.get(&txid) {
+                    for txid in &tx.conflicting_txs {
+                        let tx: Option<&d::GetTxRes> = match cache.get(txid) {
                             Some(tx) => tx.as_ref(),
                             None => {
                                 let tx = self.get_transaction(&txid);
-                                txs_to_cache.push((txid, tx));
+                                txs_to_cache.push((*txid, tx));
                                 txs_to_cache.last().unwrap().1.as_ref()
                             }
                         };
@@ -190,7 +190,7 @@ impl BitcoinInterface for d::BitcoinD {
                                 if block_height > 1 {
                                     spent.push((
                                         *op,
-                                        txid,
+                                        *txid,
                                         tx.block_time.expect("Spend is confirmed"),
                                     ))
                                 }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -28,7 +28,7 @@ fn update_coins(
     previous_tip: &BlockChainTip,
 ) -> UpdatedCoins {
     // Start by fetching newly received coins.
-    let curr_coins = db_conn.list_unspent_coins();
+    let curr_coins = db_conn.unspent_coins();
     let mut received = Vec::new();
     for utxo in bit.received_coins(&previous_tip) {
         if let Some(derivation_index) = db_conn.derivation_index_by_address(&utxo.address) {

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -15,6 +15,7 @@ struct UpdatedCoins {
     pub received: Vec<Coin>,
     pub confirmed: Vec<(bitcoin::OutPoint, i32, u32)>,
     pub spending: Vec<(bitcoin::OutPoint, bitcoin::Txid)>,
+    pub spent: Vec<(bitcoin::OutPoint, bitcoin::Txid, u32)>,
 }
 
 // Update the state of our coins. There may be new unspent, and existing ones may become confirmed
@@ -27,7 +28,7 @@ fn update_coins(
     previous_tip: &BlockChainTip,
 ) -> UpdatedCoins {
     // Start by fetching newly received coins.
-    let curr_coins = db_conn.unspent_coins();
+    let curr_coins = db_conn.list_unspent_coins();
     let mut received = Vec::new();
     for utxo in bit.received_coins(&previous_tip) {
         if let Some(derivation_index) = db_conn.derivation_index_by_address(&utxo.address) {
@@ -87,10 +88,21 @@ fn update_coins(
         .collect();
     let spending = bit.spending_coins(&to_be_spent);
 
+    // We need to confirm coins that are currently spending and which transactions are now in a
+    // block.
+    let mut spending_coins: Vec<(bitcoin::OutPoint, bitcoin::Txid)> = db_conn
+        .list_spending_coins()
+        .values()
+        .map(|coin| (coin.outpoint, coin.spend_txid.expect("Coin is spending")))
+        .collect();
+    spending_coins.extend(&spending);
+    let spent = bit.spent_coins(spending_coins.as_slice());
+
     UpdatedCoins {
         received,
         confirmed,
         spending,
+        spent,
     }
 }
 
@@ -139,6 +151,7 @@ fn updates(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
     db_conn.new_unspent_coins(&updated_coins.received);
     db_conn.confirm_coins(&updated_coins.confirmed);
     db_conn.spend_coins(&updated_coins.spending);
+    db_conn.confirm_spend(&updated_coins.spent);
     if let Some(tip) = new_tip {
         db_conn.update_tip(&tip);
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -568,9 +568,11 @@ mod tests {
         db_conn.new_unspent_coins(&[Coin {
             outpoint: dummy_op,
             block_height: None,
+            block_time: None,
             amount: bitcoin::Amount::from_sat(100_000),
             derivation_index: bip32::ChildNumber::from(13),
             spend_txid: None,
+            spent_at: None,
         }]);
         let res = control.create_spend(&[dummy_op], &destinations, 1).unwrap();
         let tx = res.psbt.global.unsigned_tx;
@@ -660,16 +662,20 @@ mod tests {
             Coin {
                 outpoint: dummy_op_a,
                 block_height: None,
+                block_time: None,
                 amount: bitcoin::Amount::from_sat(100_000),
                 derivation_index: bip32::ChildNumber::from(13),
                 spend_txid: None,
+                spent_at: None,
             },
             Coin {
                 outpoint: dummy_op_b,
                 block_height: None,
+                block_time: None,
                 amount: bitcoin::Amount::from_sat(115_680),
                 derivation_index: bip32::ChildNumber::from(34),
                 spend_txid: None,
+                spent_at: None,
             },
         ]);
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -197,7 +197,7 @@ impl DaemonControl {
     pub fn list_coins(&self) -> ListCoinsResult {
         let mut db_conn = self.db.connection();
         let coins: Vec<ListCoinsEntry> = db_conn
-            .list_unspent_coins()
+            .unspent_coins()
             // Can't use into_values as of Rust 1.48
             .into_iter()
             .map(|(_, coin)| {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -197,7 +197,7 @@ impl DaemonControl {
     pub fn list_coins(&self) -> ListCoinsResult {
         let mut db_conn = self.db.connection();
         let coins: Vec<ListCoinsEntry> = db_conn
-            .unspent_coins()
+            .list_unspent_coins()
             // Can't use into_values as of Rust 1.48
             .into_iter()
             .map(|(_, coin)| {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -55,7 +55,7 @@ pub trait DatabaseConnection {
     ) -> Option<bip32::ChildNumber>;
 
     /// Get all UTxOs.
-    fn list_unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
+    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
 
     /// List coins that are being spent and whose spending transaction is still unconfirmed.
     fn list_spending_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
@@ -118,8 +118,8 @@ impl DatabaseConnection for SqliteConn {
         self.increment_derivation_index(secp)
     }
 
-    fn list_unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
-        self.list_unspent_coins()
+    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
+        self.unspent_coins()
             .into_iter()
             .map(|db_coin| (db_coin.outpoint, db_coin.into()))
             .collect()

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -253,7 +253,7 @@ impl SqliteConn {
     }
 
     /// Get all UTxOs.
-    pub fn list_unspent_coins(&mut self) -> Vec<DbCoin> {
+    pub fn unspent_coins(&mut self) -> Vec<DbCoin> {
         db_query(
             &mut self.conn,
             "SELECT * FROM coins WHERE spend_txid is NULL",
@@ -553,7 +553,7 @@ mod tests {
             let mut conn = db.connection().unwrap();
 
             // Necessarily empty at first.
-            assert!(conn.list_unspent_coins().is_empty());
+            assert!(conn.unspent_coins().is_empty());
 
             // Add one, we'll get it.
             let coin_a = Coin {
@@ -569,7 +569,7 @@ mod tests {
                 spent_at: None,
             };
             conn.new_unspent_coins(&[coin_a.clone()]); // On 1.48, arrays aren't IntoIterator
-            assert_eq!(conn.list_unspent_coins()[0].outpoint, coin_a.outpoint);
+            assert_eq!(conn.unspent_coins()[0].outpoint, coin_a.outpoint);
 
             // We can query it by its outpoint
             let coins = conn.db_coins(&[coin_a.outpoint]);
@@ -591,7 +591,7 @@ mod tests {
             };
             conn.new_unspent_coins(&[coin_b.clone()]);
             let outpoints: HashSet<bitcoin::OutPoint> = conn
-                .list_unspent_coins()
+                .unspent_coins()
                 .into_iter()
                 .map(|c| c.outpoint)
                 .collect();
@@ -620,7 +620,7 @@ mod tests {
             let height = 174500;
             let time = 174500;
             conn.confirm_coins(&[(coin_a.outpoint, height, time)]);
-            let coins = conn.list_unspent_coins();
+            let coins = conn.unspent_coins();
             assert_eq!(coins[0].block_height, Some(height));
             assert_eq!(coins[0].block_time, Some(time));
             assert!(coins[1].block_height.is_none());
@@ -632,7 +632,7 @@ mod tests {
                 bitcoin::Txid::from_slice(&[0; 32][..]).unwrap(),
             )]);
             let outpoints: HashSet<bitcoin::OutPoint> = conn
-                .list_unspent_coins()
+                .unspent_coins()
                 .into_iter()
                 .map(|c| c.outpoint)
                 .collect();

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -48,11 +48,11 @@ impl BitcoinInterface for DummyBitcoind {
         Vec::new()
     }
 
-    fn confirmed_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32)> {
+    fn confirmed_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32, u32)> {
         Vec::new()
     }
 
-    fn spent_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {
+    fn spending_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {
         Vec::new()
     }
 }
@@ -121,21 +121,35 @@ impl DatabaseConnection for DummyDbConn {
         }
     }
 
-    fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32)]) {
-        for (op, height) in outpoints {
+    fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32, u32)]) {
+        for (op, height, time) in outpoints {
             let mut db = self.db.write().unwrap();
-            let h = &mut db.coins.get_mut(op).unwrap().block_height;
-            assert!(h.is_none());
-            *h = Some(*height);
+            let coin = &mut db.coins.get_mut(op).unwrap();
+            assert!(coin.block_height.is_none());
+            assert!(coin.block_time.is_none());
+            coin.block_height = Some(*height);
+            coin.block_time = Some(*time);
         }
     }
 
     fn spend_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]) {
         for (op, spend_txid) in outpoints {
             let mut db = self.db.write().unwrap();
-            let spender = &mut db.coins.get_mut(op).unwrap().spend_txid;
-            assert!(spender.is_none());
-            *spender = Some(*spend_txid);
+            let spent = &mut db.coins.get_mut(op).unwrap();
+            assert!(spent.spend_txid.is_none());
+            assert!(spent.spent_at.is_none());
+            spent.spend_txid = Some(*spend_txid);
+        }
+    }
+
+    fn confirm_spend<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, u32)]) {
+        for (op, spend_txid, time) in outpoints {
+            let mut db = self.db.write().unwrap();
+            let spent = &mut db.coins.get_mut(op).unwrap();
+            assert!(!spent.spend_txid.is_none());
+            assert!(spent.spent_at.is_none());
+            spent.spend_txid = Some(*spend_txid);
+            spent.spent_at = Some(*time);
         }
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -114,7 +114,7 @@ impl DatabaseConnection for DummyDbConn {
         self.db.write().unwrap().curr_index = next_index;
     }
 
-    fn list_unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
+    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
         self.db.read().unwrap().coins.clone()
     }
 


### PR DESCRIPTION
Add two new columns:

- `blocktime`: timestamp of the block containing the transaction funding the coin.
- `spent_at`: timestamp of the block containing the transaction spending the coin.

Update the coin `spent_at` when the spend transaction is confirmed