### PR TITLE
ci: add a Cirrus configuration for the functional tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,52 @@
+task:
+  name: 'Functional tests'
+  container:
+    image: rust:latest
+  timeout_in: 90m  # https://cirrus-ci.org/faq/#instance-timed-out
+
+  env:
+    EXECUTOR_WORKERS: 3
+    VERBOSE: 0
+    LOG_LEVEL: debug
+    TIMEOUT: 300
+  matrix:
+    - name: 'Misc functional tests'
+      env:
+        TEST_GROUP: tests/test_misc.py
+    - name: 'RPC functional tests'
+      env:
+        TEST_GROUP: tests/test_rpc.py
+
+  cargo_registry_cache:
+    folders: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  cargo_git_cache:
+    folders: $CARGO_HOME/git  # It will fail if they aren't separated
+    fingerprint_script: cat Cargo.lock
+  target_cache:
+    folder: target
+    fingerprint_script:
+      - rustc --version
+      - cat Cargo.lock
+  minisafed_build_script: cargo build --release
+
+  deps_script: apt update && apt install -y python3 python3-pip
+
+  pip_cache:
+    folder: ~/.cache/pip
+  python_deps_script: pip install -r tests/requirements.txt
+
+  test_script: |
+    set -xe
+
+    # Download the bitcoind binary
+    # TODO: cleanup by using env variables like in revaultd once 24.0 is out.
+    ARCHIVE_NAME="bitcoin-core-24.0rc1.tar.gz"
+    curl https://bitcoincore.org/bin/bitcoin-core-24.0/test.rc1/bitcoin-24.0rc1-x86_64-linux-gnu.tar.gz -o $ARCHIVE_NAME
+    tar -xzf $ARCHIVE_NAME
+    export BITCOIND_PATH=bitcoin-24.0rc1/bin/bitcoind
+
+    # Run the functional tests
+    MINISAFED_PATH=$PWD/target/release/minisafed pytest $TEST_GROUP -vvv -n 2
+
+  before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
Taken and adapted from revaultd.

Now that 24.0rc1 of Bitcoin Core is released we can actually have a CI for functional tests.

Fixes #14.