### PR TITLE
Chain reorganization handling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,9 @@ task:
     - name: 'RPC functional tests'
       env:
         TEST_GROUP: tests/test_rpc.py
+    - name: 'Chain functional tests'
+      env:
+        TEST_GROUP: tests/test_chain.py
 
   cargo_registry_cache:
     folders: $CARGO_HOME/registry

--- a/doc/API.md
+++ b/doc/API.md
@@ -70,7 +70,7 @@ This command does not take any parameter for now.
 
 ### `listcoins`
 
-List our current Unspent Transaction Outputs.
+List all our transaction outputs, regardless of their state (unspent or not).
 
 #### Request
 
@@ -83,7 +83,7 @@ This command does not take any parameter for now.
 
 | Field          | Type          | Description                                                      |
 | -------------- | ------------- | ---------------------------------------------------------------- |
-| `amount`       | int           | Value of the UTxO in satoshis                                    |
+| `amount`       | int           | Value of the TxO in satoshis                                     |
 | `outpoint`     | string        | Transaction id and output index of this coin                     |
 | `block_height` | int or null   | Blockheight the transaction was confirmed at, or `null`          |
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -45,7 +45,7 @@ This command does not take any parameter for now.
 | -------------------- | ------- | -------------------------------------------------------------------------------------------- |
 | `version`            | string  | Version following the [SimVer](http://www.simver.org/) format                                |
 | `network`            | string  | Answer can be `mainnet`, `testnet`, `regtest`                                                |
-| `blockheight`        | integer | Current block height                                                                         |
+| `blockheight`        | integer | The block height we are synced at.                                                           |
 | `sync`               | float   | The synchronization progress as percentage (`0 < sync < 1`)                                  |
 | `descriptors`        | object  | Object with the name of the descriptor as key and the descriptor string as value             |
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -81,11 +81,20 @@ This command does not take any parameter for now.
 
 #### Response
 
-| Field          | Type          | Description                                                      |
-| -------------- | ------------- | ---------------------------------------------------------------- |
-| `amount`       | int           | Value of the TxO in satoshis                                     |
-| `outpoint`     | string        | Transaction id and output index of this coin                     |
-| `block_height` | int or null   | Blockheight the transaction was confirmed at, or `null`          |
+| Field          | Type          | Description                                                                                                        |
+| -------------- | ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `amount`       | int           | Value of the TxO in satoshis.                                                                                      |
+| `outpoint`     | string        | Transaction id and output index of this coin.                                                                      |
+| `block_height` | int or null   | Blockheight the transaction was confirmed at, or `null`.                                                           |
+| `spend_info`   | object        | Information about the transaction spending this coin. See [Spending transaction info](#spending_transaction_info). |
+
+
+##### Spending transaction info
+
+| Field      | Type        | Description                                                    |
+| ---------- | ----------- | -------------------------------------------------------------- |
+| `txid`     | str         | Spending transaction's id.                                     |
+| `height`   | int or null | Block height the spending tx was included at, if confirmed.    |
 
 
 ### `createspend`

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -9,7 +9,7 @@ use d::LSBlockEntry;
 use std::collections::HashMap;
 use std::sync;
 
-use miniscript::bitcoin::{self, hashes::Hash};
+use miniscript::bitcoin;
 
 /// Information about the best block in the chain
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
@@ -139,10 +139,10 @@ impl BitcoinInterface for d::BitcoinD {
                 } else {
                     // TODO: better handling of this edge case.
                     log::error!(
-                        "Could not get spender of '{}'. Using a dummy spending txid.",
+                        "Could not get spender of '{}'. Not reporting it as spending.",
                         op
                     );
-                    bitcoin::Txid::from_slice(&[0; 32][..]).unwrap()
+                    continue;
                 };
 
                 spent.push((*op, spending_txid));

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -6,8 +6,7 @@ pub mod poller;
 
 use d::LSBlockEntry;
 
-use std::collections::HashMap;
-use std::sync;
+use std::{collections::HashMap, fmt, sync};
 
 use miniscript::bitcoin;
 
@@ -16,6 +15,12 @@ use miniscript::bitcoin;
 pub struct BlockChainTip {
     pub hash: bitcoin::BlockHash,
     pub height: i32,
+}
+
+impl fmt::Display for BlockChainTip {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{})", self.height, self.hash)
+    }
 }
 
 /// Our Bitcoin backend.

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -43,7 +43,7 @@ fn update_coins(
                     block_height: None,
                     block_time: None,
                     spend_txid: None,
-                    spent_at: None,
+                    spend_block_time: None,
                 };
                 received.push(coin);
             }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -28,7 +28,7 @@ fn update_coins(
     previous_tip: &BlockChainTip,
 ) -> UpdatedCoins {
     // Start by fetching newly received coins.
-    let curr_coins = db_conn.unspent_coins();
+    let curr_coins = db_conn.coins();
     let mut received = Vec::new();
     for utxo in bit.received_coins(previous_tip) {
         if let Some(derivation_index) = db_conn.derivation_index_by_address(&utxo.address) {

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -15,7 +15,7 @@ struct UpdatedCoins {
     pub received: Vec<Coin>,
     pub confirmed: Vec<(bitcoin::OutPoint, i32, u32)>,
     pub spending: Vec<(bitcoin::OutPoint, bitcoin::Txid)>,
-    pub spent: Vec<(bitcoin::OutPoint, bitcoin::Txid, u32)>,
+    pub spent: Vec<(bitcoin::OutPoint, bitcoin::Txid, i32, u32)>,
 }
 
 // Update the state of our coins. There may be new unspent, and existing ones may become confirmed
@@ -43,7 +43,7 @@ fn update_coins(
                     block_height: None,
                     block_time: None,
                     spend_txid: None,
-                    spend_block_time: None,
+                    spend_block: None,
                 };
                 received.push(coin);
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -193,11 +193,11 @@ impl DaemonControl {
         GetAddressResult { address }
     }
 
-    /// Get a list of all currently unspent coins.
+    /// Get a list of all known coins.
     pub fn list_coins(&self) -> ListCoinsResult {
         let mut db_conn = self.db.connection();
         let coins: Vec<ListCoinsEntry> = db_conn
-            .unspent_coins()
+            .coins()
             // Can't use into_values as of Rust 1.48
             .into_iter()
             .map(|(_, coin)| {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -167,10 +167,16 @@ impl DaemonControl {
 impl DaemonControl {
     /// Get information about the current state of the daemon
     pub fn get_info(&self) -> GetInfoResult {
+        let mut db_conn = self.db.connection();
+
+        let blockheight = db_conn
+            .chain_tip()
+            .map(|tip| tip.height)
+            .unwrap_or(0);
         GetInfoResult {
             version: VERSION.to_string(),
             network: self.config.bitcoin_config.network,
-            blockheight: self.bitcoin.chain_tip().height,
+            blockheight,
             sync: self.bitcoin.sync_progress(),
             descriptors: GetInfoDescriptors {
                 main: self.config.main_descriptor.clone(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -572,7 +572,7 @@ mod tests {
             amount: bitcoin::Amount::from_sat(100_000),
             derivation_index: bip32::ChildNumber::from(13),
             spend_txid: None,
-            spend_block_time: None,
+            spend_block: None,
         }]);
         let res = control.create_spend(&[dummy_op], &destinations, 1).unwrap();
         let tx = res.psbt.global.unsigned_tx;
@@ -666,7 +666,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(100_000),
                 derivation_index: bip32::ChildNumber::from(13),
                 spend_txid: None,
-                spend_block_time: None,
+                spend_block: None,
             },
             Coin {
                 outpoint: dummy_op_b,
@@ -675,7 +675,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(115_680),
                 derivation_index: bip32::ChildNumber::from(34),
                 spend_txid: None,
-                spend_block_time: None,
+                spend_block: None,
             },
         ]);
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -572,7 +572,7 @@ mod tests {
             amount: bitcoin::Amount::from_sat(100_000),
             derivation_index: bip32::ChildNumber::from(13),
             spend_txid: None,
-            spent_at: None,
+            spend_block_time: None,
         }]);
         let res = control.create_spend(&[dummy_op], &destinations, 1).unwrap();
         let tx = res.psbt.global.unsigned_tx;
@@ -666,7 +666,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(100_000),
                 derivation_index: bip32::ChildNumber::from(13),
                 spend_txid: None,
-                spent_at: None,
+                spend_block_time: None,
             },
             Coin {
                 outpoint: dummy_op_b,
@@ -675,7 +675,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(115_680),
                 derivation_index: bip32::ChildNumber::from(34),
                 spend_txid: None,
-                spent_at: None,
+                spend_block_time: None,
             },
         ]);
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -194,7 +194,7 @@ pub struct Coin {
     pub amount: bitcoin::Amount,
     pub derivation_index: bip32::ChildNumber,
     pub spend_txid: Option<bitcoin::Txid>,
-    pub spent_at: Option<u32>,
+    pub spend_block_time: Option<u32>,
 }
 
 impl std::convert::From<DbCoin> for Coin {
@@ -206,7 +206,7 @@ impl std::convert::From<DbCoin> for Coin {
             amount,
             derivation_index,
             spend_txid,
-            spent_at,
+            spend_block_time,
             ..
         } = db_coin;
         Coin {
@@ -216,7 +216,7 @@ impl std::convert::From<DbCoin> for Coin {
             amount,
             derivation_index,
             spend_txid,
-            spent_at,
+            spend_block_time,
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -54,8 +54,8 @@ pub trait DatabaseConnection {
         address: &bitcoin::Address,
     ) -> Option<bip32::ChildNumber>;
 
-    /// Get all UTxOs.
-    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
+    /// Get all our coins, past or present, spent or not.
+    fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
 
     /// List coins that are being spent and whose spending transaction is still unconfirmed.
     fn list_spending_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin>;
@@ -121,8 +121,8 @@ impl DatabaseConnection for SqliteConn {
         self.increment_derivation_index(secp)
     }
 
-    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
-        self.unspent_coins()
+    fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
+        self.coins()
             .into_iter()
             .map(|db_coin| (db_coin.outpoint, db_coin.into()))
             .collect()

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -6,7 +6,7 @@ pub mod sqlite;
 use crate::{
     bitcoin::BlockChainTip,
     database::sqlite::{
-        schema::{DbCoin, DbTip},
+        schema::{DbCoin, DbSpendBlock, DbTip},
         SqliteConn, SqliteDb,
     },
 };
@@ -70,7 +70,7 @@ pub trait DatabaseConnection {
     fn spend_coins(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]);
 
     /// Mark a set of coins as spent by a specified txid at a specified block time.
-    fn confirm_spend(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, u32)]);
+    fn confirm_spend(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, i32, u32)]);
 
     /// Get specific coins from the database.
     fn coins_by_outpoints(
@@ -144,7 +144,7 @@ impl DatabaseConnection for SqliteConn {
         self.spend_coins(outpoints)
     }
 
-    fn confirm_spend<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, u32)]) {
+    fn confirm_spend<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, i32, u32)]) {
         self.confirm_spend(outpoints)
     }
 
@@ -187,6 +187,21 @@ impl DatabaseConnection for SqliteConn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SpendBlock {
+    pub height: i32,
+    pub time: u32,
+}
+
+impl From<DbSpendBlock> for SpendBlock {
+    fn from(b: DbSpendBlock) -> SpendBlock {
+        SpendBlock {
+            height: b.height,
+            time: b.time,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Coin {
     pub outpoint: bitcoin::OutPoint,
     pub block_height: Option<i32>,
@@ -194,7 +209,7 @@ pub struct Coin {
     pub amount: bitcoin::Amount,
     pub derivation_index: bip32::ChildNumber,
     pub spend_txid: Option<bitcoin::Txid>,
-    pub spend_block_time: Option<u32>,
+    pub spend_block: Option<SpendBlock>,
 }
 
 impl std::convert::From<DbCoin> for Coin {
@@ -206,7 +221,7 @@ impl std::convert::From<DbCoin> for Coin {
             amount,
             derivation_index,
             spend_txid,
-            spend_block_time,
+            spend_block,
             ..
         } = db_coin;
         Coin {
@@ -216,7 +231,7 @@ impl std::convert::From<DbCoin> for Coin {
             amount,
             derivation_index,
             spend_txid,
-            spend_block_time,
+            spend_block: spend_block.map(SpendBlock::from),
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -88,6 +88,9 @@ pub trait DatabaseConnection {
 
     /// Delete a Spend transaction from database.
     fn delete_spend(&mut self, txid: &bitcoin::Txid);
+
+    /// Mark the given tip as the new best seen block. Update stored data accordingly.
+    fn rollback_tip(&mut self, new_tip: &BlockChainTip);
 }
 
 impl DatabaseConnection for SqliteConn {
@@ -184,9 +187,13 @@ impl DatabaseConnection for SqliteConn {
     fn delete_spend(&mut self, txid: &bitcoin::Txid) {
         self.delete_spend(txid)
     }
+
+    fn rollback_tip(&mut self, new_tip: &BlockChainTip) {
+        self.rollback_tip(new_tip)
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SpendBlock {
     pub height: i32,
     pub time: u32,
@@ -201,7 +208,7 @@ impl From<DbSpendBlock> for SpendBlock {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Coin {
     pub outpoint: bitcoin::OutPoint,
     pub block_height: Option<i32>,

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -267,7 +267,7 @@ impl SqliteConn {
     pub fn list_spending_coins(&mut self) -> Vec<DbCoin> {
         db_query(
             &mut self.conn,
-            "SELECT * FROM coins WHERE spend_txid IS NOT NULL AND spent_at IS NULL",
+            "SELECT * FROM coins WHERE spend_txid IS NOT NULL AND spend_block_time IS NULL",
             rusqlite::params![],
             |row| row.try_into(),
         )
@@ -342,7 +342,7 @@ impl SqliteConn {
         db_exec(&mut self.conn, |db_tx| {
             for (outpoint, spend_txid, time) in outpoints {
                 db_tx.execute(
-                    "UPDATE coins SET spend_txid = ?1, spent_at = ?2 WHERE txid = ?3 AND vout = ?4",
+                    "UPDATE coins SET spend_txid = ?1, spend_block_time = ?2 WHERE txid = ?3 AND vout = ?4",
                     rusqlite::params![
                         spend_txid.to_vec(),
                         time,
@@ -566,7 +566,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(98765),
                 derivation_index: bip32::ChildNumber::from_normal_idx(10).unwrap(),
                 spend_txid: None,
-                spent_at: None,
+                spend_block_time: None,
             };
             conn.new_unspent_coins(&[coin_a.clone()]); // On 1.48, arrays aren't IntoIterator
             assert_eq!(conn.unspent_coins()[0].outpoint, coin_a.outpoint);
@@ -587,7 +587,7 @@ mod tests {
                 amount: bitcoin::Amount::from_sat(1111),
                 derivation_index: bip32::ChildNumber::from_normal_idx(103).unwrap(),
                 spend_txid: None,
-                spent_at: None,
+                spend_block_time: None,
             };
             conn.new_unspent_coins(&[coin_b.clone()]);
             let outpoints: HashSet<bitcoin::OutPoint> = conn

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -130,13 +130,13 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DbSpendBlock {
     pub height: i32,
     pub time: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DbCoin {
     pub id: i64,
     pub wallet_id: i64,

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -42,7 +42,7 @@ CREATE TABLE coins (
     derivation_index INTEGER NOT NULL,
     spend_txid BLOB,
     /* Time of the block containing the transaction spending the coin, NULL if not confirmed */
-    spent_at INTEGER,
+    spend_block_time INTEGER,
     UNIQUE (txid, vout),
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
         ON UPDATE RESTRICT
@@ -136,7 +136,7 @@ pub struct DbCoin {
     pub amount: bitcoin::Amount,
     pub derivation_index: bip32::ChildNumber,
     pub spend_txid: Option<bitcoin::Txid>,
-    pub spent_at: Option<u32>,
+    pub spend_block_time: Option<u32>,
 }
 
 impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
@@ -161,7 +161,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
         let spend_txid: Option<Vec<u8>> = row.get(8)?;
         let spend_txid =
             spend_txid.map(|txid| encode::deserialize(&txid).expect("We only store valid txids"));
-        let spent_at = row.get(9)?;
+        let spend_block_time = row.get(9)?;
 
         Ok(DbCoin {
             id,
@@ -172,7 +172,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
             amount,
             derivation_index,
             spend_txid,
-            spent_at,
+            spend_block_time,
         })
     }
 }

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -30,7 +30,11 @@ CREATE TABLE wallets (
     deposit_derivation_index INTEGER NOT NULL
 );
 
-/* Our (U)TxOs. */
+/* Our (U)TxOs.
+ *
+ * The 'spend_block_height' and 'spend_block.time' are only present if the spending
+ * transaction for this coin exists and was confirmed.
+ */
 CREATE TABLE coins (
     id INTEGER PRIMARY KEY NOT NULL,
     wallet_id INTEGER NOT NULL,
@@ -41,7 +45,7 @@ CREATE TABLE coins (
     amount_sat INTEGER NOT NULL,
     derivation_index INTEGER NOT NULL,
     spend_txid BLOB,
-    /* Time of the block containing the transaction spending the coin, NULL if not confirmed */
+    spend_block_height INTEGER,
     spend_block_time INTEGER,
     UNIQUE (txid, vout),
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
@@ -127,6 +131,12 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DbSpendBlock {
+    pub height: i32,
+    pub time: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DbCoin {
     pub id: i64,
     pub wallet_id: i64,
@@ -136,7 +146,7 @@ pub struct DbCoin {
     pub amount: bitcoin::Amount,
     pub derivation_index: bip32::ChildNumber,
     pub spend_txid: Option<bitcoin::Txid>,
-    pub spend_block_time: Option<u32>,
+    pub spend_block: Option<DbSpendBlock>,
 }
 
 impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
@@ -161,7 +171,13 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
         let spend_txid: Option<Vec<u8>> = row.get(8)?;
         let spend_txid =
             spend_txid.map(|txid| encode::deserialize(&txid).expect("We only store valid txids"));
-        let spend_block_time = row.get(9)?;
+        let spend_height: Option<i32> = row.get(9)?;
+        let spend_time: Option<u32> = row.get(10)?;
+        assert_eq!(spend_height.is_none(), spend_time.is_none());
+        let spend_block = spend_height.map(|height| DbSpendBlock {
+            height,
+            time: spend_time.expect("Must be there if height is"),
+        });
 
         Ok(DbCoin {
             id,
@@ -172,7 +188,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
             amount,
             derivation_index,
             spend_txid,
-            spend_block_time,
+            spend_block,
         })
     }
 }

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -54,7 +54,7 @@ fn update_spend(control: &DaemonControl, params: Params) -> Result<serde_json::V
         .as_str()
         .and_then(|s| base64::decode(&s).ok())
         .and_then(|bytes| consensus::deserialize(&bytes).ok())
-        .ok_or_else(|| Error::invalid_params("Invalid 'feerate' parameter."))?;
+        .ok_or_else(|| Error::invalid_params("Invalid 'psbt' parameter."))?;
     control.update_spend(psbt)?;
 
     Ok(serde_json::json!({}))
@@ -66,7 +66,7 @@ fn delete_spend(control: &DaemonControl, params: Params) -> Result<serde_json::V
         .ok_or_else(|| Error::invalid_params("Missing 'txid' parameter."))?
         .as_str()
         .and_then(|s| bitcoin::Txid::from_str(s).ok())
-        .ok_or_else(|| Error::invalid_params("Invalid 'feerate' parameter."))?;
+        .ok_or_else(|| Error::invalid_params("Invalid 'txid' parameter."))?;
     control.delete_spend(&txid);
 
     Ok(serde_json::json!({}))

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -132,7 +132,7 @@ impl DatabaseConnection for DummyDbConn {
         let mut result = HashMap::new();
         for (k, v) in self.db.read().unwrap().coins.iter() {
             if v.spend_txid.is_some() {
-                result.insert(*k, v.clone());
+                result.insert(*k, *v);
             }
         }
         result
@@ -140,11 +140,7 @@ impl DatabaseConnection for DummyDbConn {
 
     fn new_unspent_coins<'a>(&mut self, coins: &[Coin]) {
         for coin in coins {
-            self.db
-                .write()
-                .unwrap()
-                .coins
-                .insert(coin.outpoint, coin.clone());
+            self.db.write().unwrap().coins.insert(coin.outpoint, *coin);
         }
     }
 
@@ -227,6 +223,10 @@ impl DatabaseConnection for DummyDbConn {
 
     fn delete_spend(&mut self, txid: &bitcoin::Txid) {
         self.db.write().unwrap().spend_txs.remove(txid);
+    }
+
+    fn rollback_tip(&mut self, _: &BlockChainTip) {
+        todo!()
     }
 }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -124,7 +124,7 @@ impl DatabaseConnection for DummyDbConn {
         self.db.write().unwrap().curr_index = next_index;
     }
 
-    fn unspent_coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
+    fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {
         self.db.read().unwrap().coins.clone()
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -164,7 +164,7 @@ impl DatabaseConnection for DummyDbConn {
             let mut db = self.db.write().unwrap();
             let spent = &mut db.coins.get_mut(op).unwrap();
             assert!(spent.spend_txid.is_none());
-            assert!(spent.spent_at.is_none());
+            assert!(spent.spend_block_time.is_none());
             spent.spend_txid = Some(*spend_txid);
         }
     }
@@ -174,9 +174,9 @@ impl DatabaseConnection for DummyDbConn {
             let mut db = self.db.write().unwrap();
             let spent = &mut db.coins.get_mut(op).unwrap();
             assert!(spent.spend_txid.is_some());
-            assert!(spent.spent_at.is_none());
+            assert!(spent.spend_block_time.is_none());
             spent.spend_txid = Some(*spend_txid);
-            spent.spent_at = Some(*time);
+            spent.spend_block_time = Some(*time);
         }
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -62,6 +62,10 @@ impl BitcoinInterface for DummyBitcoind {
     ) -> Vec<(bitcoin::OutPoint, bitcoin::Txid, u32)> {
         Vec::new()
     }
+
+    fn common_ancestor(&self, _: &BlockChainTip) -> BlockChainTip {
+        todo!()
+    }
 }
 
 pub struct DummyDb {

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,168 @@
+from fixtures import *
+from test_framework.utils import wait_for, get_txid, spend_coins
+
+
+def get_coin(minisafed, outpoint_or_txid):
+    return next(
+        c
+        for c in minisafed.rpc.listcoins()["coins"]
+        if outpoint_or_txid in c["outpoint"]
+    )
+
+
+def test_reorg_detection(minisafed, bitcoind):
+    """Test we detect block chain reorganization under various conditions."""
+    initial_height = bitcoind.rpc.getblockcount()
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # Re-mine the last block. We should detect it as a reorg.
+    bitcoind.invalidate_remine(initial_height)
+    minisafed.wait_for_logs(
+        ["Block chain reorganization detected.", "Tip was rolled back."]
+    )
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # Same if we re-mine the next-to-last block.
+    bitcoind.invalidate_remine(initial_height - 1)
+    minisafed.wait_for_logs(
+        ["Block chain reorganization detected.", "Tip was rolled back."]
+    )
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # Same if we re-mine a deep block.
+    bitcoind.invalidate_remine(initial_height - 50)
+    minisafed.wait_for_logs(
+        ["Block chain reorganization detected.", "Tip was rolled back."]
+    )
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # Same if the new chain is longer.
+    bitcoind.simple_reorg(initial_height - 10, shift=20)
+    minisafed.wait_for_logs(
+        ["Block chain reorganization detected.", "Tip was rolled back."]
+    )
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height + 10)
+
+
+def test_reorg_exclusion(minisafed, bitcoind):
+    """Test the unconfirmation by a reorg of a coin in various states."""
+    initial_height = bitcoind.rpc.getblockcount()
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # A confirmed received coin
+    addr = minisafed.rpc.getnewaddress()["address"]
+    txid = bitcoind.rpc.sendtoaddress(addr, 1)
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 1)
+    coin_a = minisafed.rpc.listcoins()["coins"][0]
+
+    # A confirmed and 'spending' (unconfirmed spend) coin
+    addr = minisafed.rpc.getnewaddress()["address"]
+    txid = bitcoind.rpc.sendtoaddress(addr, 2)
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 2)
+    coin_b = get_coin(minisafed, txid)
+    b_spend_tx = spend_coins(minisafed, bitcoind, [coin_b])
+
+    # A confirmed and spent coin
+    addr = minisafed.rpc.getnewaddress()["address"]
+    txid = bitcoind.rpc.sendtoaddress(addr, 3)
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 3)
+    coin_c = get_coin(minisafed, txid)
+    c_spend_tx = spend_coins(minisafed, bitcoind, [coin_c])
+    bitcoind.generate_block(1, wait_for_mempool=1)
+
+    # Reorg the chain down to the initial height, excluding all transactions.
+    current_height = bitcoind.rpc.getblockcount()
+    bitcoind.simple_reorg(initial_height, shift=-1)
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == current_height + 1)
+
+    # They must all be marked as unconfirmed.
+    new_coin_a = get_coin(minisafed, coin_a["outpoint"])
+    assert new_coin_a["block_height"] is None
+    new_coin_b = get_coin(minisafed, coin_b["outpoint"])
+    assert new_coin_b["block_height"] is None
+    new_coin_c = get_coin(minisafed, coin_c["outpoint"])
+    assert new_coin_c["block_height"] is None
+
+    # And if we now confirm everything, they'll be marked as such. The one that was 'spending'
+    # will now be spent (its spending transaction will be confirmed) and the one that was spent
+    # will be marked as such.
+    deposit_txids = [c["outpoint"][:-2] for c in (coin_a, coin_b, coin_c)]
+    for txid in deposit_txids:
+        tx = bitcoind.rpc.gettransaction(txid)["hex"]
+        bitcoind.rpc.sendrawtransaction(tx)
+    bitcoind.rpc.sendrawtransaction(b_spend_tx)
+    bitcoind.rpc.sendrawtransaction(c_spend_tx)
+    bitcoind.generate_block(1, wait_for_mempool=5)
+    new_height = bitcoind.rpc.getblockcount()
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == new_height)
+    assert all(
+        c["block_height"] == new_height for c in minisafed.rpc.listcoins()["coins"]
+    ), (minisafed.rpc.listcoins()["coins"], new_height)
+    new_coin_b = next(
+        c
+        for c in minisafed.rpc.listcoins()["coins"]
+        if coin_b["outpoint"] == c["outpoint"]
+    )
+    b_spend_txid = get_txid(b_spend_tx)
+    assert new_coin_b["spend_info"]["txid"] == b_spend_txid
+    assert new_coin_b["spend_info"]["height"] == new_height
+    new_coin_c = next(
+        c
+        for c in minisafed.rpc.listcoins()["coins"]
+        if coin_c["outpoint"] == c["outpoint"]
+    )
+    c_spend_txid = get_txid(c_spend_tx)
+    assert new_coin_c["spend_info"]["txid"] == c_spend_txid
+    assert new_coin_c["spend_info"]["height"] == new_height
+
+    # TODO: maybe test with some malleation for the deposit and spending txs?
+
+
+def spend_confirmed_noticed(minisafed, outpoint):
+    c = get_coin(minisafed, outpoint)
+    if c["spend_info"] is None:
+        return False
+    if c["spend_info"]["height"] is None:
+        return False
+    return True
+
+
+def test_reorg_status_recovery(minisafed, bitcoind):
+    """
+    Test the coins that were not unconfirmed recover their initial state after a reorg.
+    """
+    list_coins = lambda: minisafed.rpc.listcoins()["coins"]
+
+    # Create two confirmed coins. Note how we take the initial_height after having
+    # mined them, as we'll reorg back to this height and due to anti fee-sniping
+    # these deposit transactions might not be valid anymore!
+    addresses = (minisafed.rpc.getnewaddress()["address"] for _ in range(2))
+    txids = [bitcoind.rpc.sendtoaddress(addr, 0.5670) for addr in addresses]
+    bitcoind.generate_block(1, wait_for_mempool=txids)
+    initial_height = bitcoind.rpc.getblockcount()
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == initial_height)
+
+    # Both coins are confirmed. Spend the second one then get their infos.
+    wait_for(lambda: len(list_coins()) == 2)
+    wait_for(lambda: all(c["block_height"] is not None for c in list_coins()))
+    coin_b = get_coin(minisafed, txids[1])
+    spend_coins(minisafed, bitcoind, [coin_b])
+    bitcoind.generate_block(1, wait_for_mempool=1)
+    wait_for(lambda: spend_confirmed_noticed(minisafed, coin_b["outpoint"]))
+    coin_a = get_coin(minisafed, txids[0])
+    coin_b = get_coin(minisafed, txids[1])
+
+    # Reorg the chain down to the initial height without shifting nor malleating
+    # any transaction. The coin info should be identical (except the transaction
+    # spending the second coin will be mined at the height the reorg happened).
+    bitcoind.simple_reorg(initial_height, shift=0)
+    new_height = bitcoind.rpc.getblockcount()
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == new_height)
+    new_coin_a = get_coin(minisafed, coin_a["outpoint"])
+    assert coin_a == new_coin_a
+    new_coin_b = get_coin(minisafed, coin_b["outpoint"])
+    coin_b["spend_info"]["height"] = initial_height
+    assert new_coin_b == coin_b

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -137,7 +137,6 @@ class Bitcoind(TailableProc):
         Reorganize chain by creating a fork at height={height} and:
             - If shift >=0:
                 - re-mine all mempool transactions into {height} + shift
-                  (with shift floored at 1)
             - Else:
                 - don't re-mine the mempool transactions
 

--- a/tests/test_framework/bitcoind.py
+++ b/tests/test_framework/bitcoind.py
@@ -126,6 +126,12 @@ class Bitcoind(TailableProc):
         for _ in range(n):
             self.rpc.generateblock(addr, [])
 
+    def invalidate_remine(self, height):
+        delta = self.rpc.getblockcount() - height + 1
+        h = self.rpc.getblockhash(height)
+        self.rpc.invalidateblock(h)
+        self.generate_empty_blocks(delta)
+
     def simple_reorg(self, height, shift=0):
         """
         Reorganize chain by creating a fork at height={height} and:

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -7,7 +7,7 @@ def test_getinfo(minisafed):
     res = minisafed.rpc.getinfo()
     assert res["version"] == "0.1"
     assert res["network"] == "regtest"
-    assert res["blockheight"] == 101
+    wait_for(lambda: res["blockheight"] == 101)
     assert res["sync"] == 1.0
     assert "main" in res["descriptors"]
 


### PR DESCRIPTION
This finally implements our reorganization handling. Like in revaultd, upon noticing a tip change that indicates a reorg happened in our Bitcoin backend we rollback our state to the common ancestor between our state and the new chain, then start rescanning from there. The logic is much more straightforward than in revaultd though, as there is no presigned transactions to care about.

The PR grew a bit large as this needed a bit of preparatory work in order to be reasonably tested (and i noticed a few bugs and cleanups that slipped through review in #29). Please let me know if reviewers prefer that i split the prep work on the commands in another PR.

Fixes #15.