### PR TITLE
A new `broadcastspend` command

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -12,6 +12,7 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`getnewaddress`](#getnewaddress)                           | Get a new receiving address                          |
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                   |
 | [`delspendtx`](#delspendtx)                                 | Delete a stored Spend transaction                    |
+| [`broadcastspend`](#broadcastspend)                         | Finalize a stored Spend PSBT, and broadcast it       |
 
 # Reference
 
@@ -175,6 +176,22 @@ This command does not take any parameter for now.
 | Field    | Type   | Description                                         |
 | -------- | ------ | --------------------------------------------------- |
 | `txid`   | string | Hex encoded txid of the Spend transaction to delete |
+
+#### Response
+
+This command does not return anything for now.
+
+| Field          | Type      | Description                                          |
+| -------------- | --------- | ---------------------------------------------------- |
+
+
+### `broadcastspend`
+
+#### Request
+
+| Field    | Type   | Description                                            |
+| -------- | ------ | ------------------------------------------------------ |
+| `txid`   | string | Hex encoded txid of the Spend transaction to broadcast |
 
 #### Response
 

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -679,6 +679,14 @@ impl BitcoinD {
             blockhash,
         }
     }
+
+    pub fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), BitcoindError> {
+        self.make_fallible_node_request(
+            "sendrawtransaction",
+            &params!(bitcoin::consensus::encode::serialize_hex(tx)),
+        )?;
+        Ok(())
+    }
 }
 // Bitcoind uses a guess for the value of verificationprogress. It will eventually get to
 // be 1, and we want to be less conservative.

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
+    bitcoin::{BitcoinError, BitcoinInterface, BlockChainTip, UTxO},
     config::{BitcoinConfig, Config},
     database::{Coin, DatabaseConnection, DatabaseInterface, SpendBlock},
     DaemonHandle,
@@ -64,6 +64,10 @@ impl BitcoinInterface for DummyBitcoind {
     }
 
     fn common_ancestor(&self, _: &BlockChainTip) -> BlockChainTip {
+        todo!()
+    }
+
+    fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), BitcoinError> {
         todo!()
     }
 }

--- a/tests/test_framework/minisafed.py
+++ b/tests/test_framework/minisafed.py
@@ -16,6 +16,10 @@ from test_framework.serializations import (
     sighash_all_witness,
     CTxInWitness,
     CScriptWitness,
+    PSBT_IN_BIP32_DERIVATION,
+    PSBT_IN_WITNESS_SCRIPT,
+    PSBT_IN_PARTIAL_SIG,
+    PSBT_IN_FINAL_SCRIPTWITNESS,
 )
 
 
@@ -65,11 +69,12 @@ class Minisafed(TailableProc):
         assert isinstance(psbt, PSBT)
 
         # Sign each input.
-        for i, psbt_in in enumerate(psbt.inputs):
+        for i, psbt_in in enumerate(psbt.i):
             # First, gather the needed information from the PSBT input.
-            # 'hd_keypaths' is of the form {pubkey: (fingerprint, derivation index)}
-            der_index = next(iter(psbt_in.hd_keypaths.values()))[1]
-            script_code = psbt_in.witness_script
+            # 'hd_keypaths' is of the form {pubkey: (fingerprint (4 bytes), derivation index (4 bytes))}
+            fing_der = next(iter(psbt_in.map[PSBT_IN_BIP32_DERIVATION].values()))
+            der_index = int.from_bytes(fing_der[4:], byteorder="little", signed=True)
+            script_code = psbt_in.map[PSBT_IN_WITNESS_SCRIPT]
 
             # Now sign the transaction with the key of the "owner" (the participant that
             # can sign immediately without a timelock)
@@ -78,10 +83,14 @@ class Minisafed(TailableProc):
                 self.owner_hd.get_privkey_from_path([der_index])
             )
             pubkey = privkey.public_key.format()
-            assert pubkey in psbt_in.hd_keypaths.keys()
+            assert pubkey in psbt_in.map[PSBT_IN_BIP32_DERIVATION].keys(), (
+                pubkey,
+                psbt_in.map[PSBT_IN_BIP32_DERIVATION].keys(),
+            )
             sig = privkey.sign(sighash, hasher=None) + b"\x01"
             logging.debug(f"Adding signature {sig.hex()} for pubkey {pubkey.hex()}")
-            psbt_in.partial_sigs[pubkey] = sig
+            assert PSBT_IN_PARTIAL_SIG not in psbt_in.map
+            psbt_in.map[PSBT_IN_PARTIAL_SIG] = {pubkey: sig}
 
         return psbt
 
@@ -95,25 +104,28 @@ class Minisafed(TailableProc):
         assert isinstance(psbt, PSBT)
 
         # Create a witness for each input of the transaction.
-        for i, psbt_in in enumerate(psbt.inputs):
+        for i, psbt_in in enumerate(psbt.i):
             # First, gather the needed information from the PSBT input.
             # 'hd_keypaths' is of the form {pubkey: (fingerprint, derivation index)}
-            der_index = next(iter(psbt_in.hd_keypaths.values()))[1]
+            fing_der = next(iter(psbt_in.map[PSBT_IN_BIP32_DERIVATION].values()))
+            der_index = int.from_bytes(fing_der[4:], byteorder="little", signed=True)
 
             # Create a copy of the descriptor to derive it at the index used in this input.
             # Then create a satisfaction for it using the signature we just created.
             desc = Descriptor.from_str(str(self.main_desc))
             desc.derive(der_index)
             sat_material = SatisfactionMaterial(
-                signatures=psbt_in.partial_sigs,
+                signatures=psbt_in.map[PSBT_IN_PARTIAL_SIG],
             )
             stack = desc.satisfy(sat_material)
             logging.debug(f"Satisfaction for {desc} is {[e.hex() for e in stack]}")
 
             # Update the transaction inside the PSBT directly.
             assert stack is not None
-            psbt_in.final_script_witness = CTxInWitness(CScriptWitness(stack))
-            psbt.tx.wit.vtxinwit.append(psbt_in.final_script_witness)
+            psbt_in.map[PSBT_IN_FINAL_SCRIPTWITNESS] = CTxInWitness(
+                CScriptWitness(stack)
+            )
+            psbt.tx.wit.vtxinwit.append(psbt_in.map[PSBT_IN_FINAL_SCRIPTWITNESS])
 
         return psbt
 

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -67,9 +67,7 @@ def spend_coins(minisafed, bitcoind, coins):
     }
     res = minisafed.rpc.createspend([c["outpoint"] for c in coins], destinations, 1)
 
-    psbt = PSBT()
-    psbt.deserialize(res["psbt"])
-    signed_psbt = minisafed.sign_psbt(psbt)
+    signed_psbt = minisafed.sign_psbt(PSBT.from_base64(res["psbt"]))
     finalized_psbt = minisafed.finalize_psbt(signed_psbt)
     tx = finalized_psbt.tx.serialize_with_witness().hex()
     bitcoind.rpc.sendrawtransaction(tx)

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -69,7 +69,9 @@ def spend_coins(minisafed, bitcoind, coins):
 
     psbt = PSBT()
     psbt.deserialize(res["psbt"])
-    tx = minisafed.sign_psbt(psbt)
+    signed_psbt = minisafed.sign_psbt(psbt)
+    finalized_psbt = minisafed.finalize_psbt(signed_psbt)
+    tx = finalized_psbt.tx.serialize_with_witness().hex()
     bitcoind.rpc.sendrawtransaction(tx)
 
     return tx
@@ -184,6 +186,7 @@ class UnixDomainSocketRpc(object):
         We might still want to define the actual methods in the subclasses for
         documentation purposes.
         """
+
         def wrapper(*args, **kwargs):
             if len(args) != 0 and len(kwargs) != 0:
                 raise RpcError(

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -187,9 +187,6 @@ def test_update_spend(minisafed, bitcoind):
     assert len(list_res) == 1
     assert list_res[0]["psbt"] == res["psbt"]
 
-    # Keep a copy for later.
-    psbt_no_sig = PSBT.from_base64(res["psbt"])
-
     # We can add a signature and update it
     psbt_sig_a = PSBT.from_base64(res["psbt"])
     dummy_pk_a = bytes.fromhex(


### PR DESCRIPTION
This implements a new command to broadcast an existing Spend transaction.

Fixes #58.
Fixes #66.