### PR TITLE
Decent change management (using multipath descriptors)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,8 +256,7 @@ dependencies = [
 [[package]]
 name = "miniscript"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4975078076f0b7b914a3044ad7432d2a7fcec38edb855afdc672e24ca35b69"
+source = "git+https://github.com/darosior/rust-miniscript?branch=multipath_descriptors_on_8.0#7d756f2ab066d85d299f711f953ebda15f14e832"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ jsonrpc_server = []
 
 [dependencies]
 # For managing transactions (it re-exports the bitcoin crate)
-miniscript = { version = "8.0", features = ["serde"] }
+# TODO: don't use my fork for a real release..
+miniscript = { git = "https://github.com/darosior/rust-miniscript", branch = "multipath_descriptors_on_8.0", features = ["serde"] }
 
 # Don't reinvent the wheel
 dirs = "3.0"

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -528,7 +528,13 @@ impl BitcoinD {
     pub fn list_since_block(&self, block_hash: &bitcoin::BlockHash) -> LSBlockRes {
         self.make_wallet_request(
             "listsinceblock",
-            &params!(Json::String(block_hash.to_string()),),
+            &params!(
+                Json::String(block_hash.to_string()),
+                Json::Number(1.into()), // Default for min_confirmations for the returned
+                Json::Bool(true),       // Whether to include watchonly
+                Json::Bool(false),      // Whether to include an array of txs that were removed in reorgs
+                Json::Bool(true)        // Whether to include UTxOs treated as change.
+            ),
         )
         .into()
     }

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -1,7 +1,7 @@
 ///! Implementation of the Bitcoin interface using bitcoind.
 ///!
 ///! We use the RPC interface and a watchonly descriptor wallet.
-use crate::{bitcoin::BlockChainTip, config, descriptors::InheritanceDescriptor};
+use crate::{bitcoin::BlockChainTip, config, descriptors::MultipathDescriptor};
 
 use std::{collections::HashSet, convert::TryInto, fs, io, str::FromStr, time::Duration};
 
@@ -352,7 +352,7 @@ impl BitcoinD {
     }
 
     // Import the receive and change descriptors from the multipath descriptor to bitcoind.
-    fn import_descriptor(&self, desc: &InheritanceDescriptor) -> Option<String> {
+    fn import_descriptor(&self, desc: &MultipathDescriptor) -> Option<String> {
         let descriptors = [desc.receive_descriptor(), desc.change_descriptor()]
             .iter()
             .map(|desc| {
@@ -401,7 +401,7 @@ impl BitcoinD {
     /// Create the watchonly wallet on bitcoind, and import it the main descriptor.
     pub fn create_watchonly_wallet(
         &self,
-        main_descriptor: &InheritanceDescriptor,
+        main_descriptor: &MultipathDescriptor,
     ) -> Result<(), BitcoindError> {
         // Remove any leftover. This can happen if we delete the watchonly wallet but don't restart
         // bitcoind.
@@ -441,7 +441,7 @@ impl BitcoinD {
     /// Perform various sanity checks on the bitcoind instance.
     pub fn sanity_check(
         &self,
-        main_descriptor: &InheritanceDescriptor,
+        main_descriptor: &MultipathDescriptor,
         config_network: bitcoin::Network,
     ) -> Result<(), BitcoindError> {
         // Check the minimum supported bitcoind version

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -219,7 +219,7 @@ pub fn looper(
     db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
     shutdown: sync::Arc<atomic::AtomicBool>,
     poll_interval: time::Duration,
-    desc: descriptors::InheritanceDescriptor,
+    desc: descriptors::MultipathDescriptor,
 ) {
     let mut last_poll = None;
     let mut synced = false;

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -223,7 +223,10 @@ pub fn looper(
 ) {
     let mut last_poll = None;
     let mut synced = false;
-    let descs = [desc.receive_descriptor(), desc.change_descriptor()];
+    let descs = [
+        desc.receive_descriptor().clone(),
+        desc.change_descriptor().clone(),
+    ];
 
     maybe_initialize_tip(&bit, &db);
 

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -35,7 +35,9 @@ fn update_coins(
     // Start by fetching newly received coins.
     let mut received = Vec::new();
     for utxo in bit.received_coins(previous_tip, descs) {
-        if let Some(derivation_index) = db_conn.derivation_index_by_address(&utxo.address) {
+        if let Some((derivation_index, is_change)) =
+            db_conn.derivation_index_by_address(&utxo.address)
+        {
             if !curr_coins.contains_key(&utxo.outpoint) {
                 let UTxO {
                     outpoint, amount, ..
@@ -44,6 +46,7 @@ fn update_coins(
                     outpoint,
                     amount,
                     derivation_index,
+                    is_change,
                     block_height: None,
                     block_time: None,
                     spend_txid: None,

--- a/src/bitcoin/poller/mod.rs
+++ b/src/bitcoin/poller/mod.rs
@@ -22,7 +22,7 @@ impl Poller {
         bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         poll_interval: time::Duration,
-        desc: descriptors::InheritanceDescriptor,
+        desc: descriptors::MultipathDescriptor,
     ) -> Poller {
         let shutdown = sync::Arc::from(atomic::AtomicBool::from(false));
         let handle = thread::Builder::new()

--- a/src/bitcoin/poller/mod.rs
+++ b/src/bitcoin/poller/mod.rs
@@ -3,6 +3,7 @@ mod looper;
 use crate::{
     bitcoin::{poller::looper::looper, BitcoinInterface},
     database::DatabaseInterface,
+    descriptors,
 };
 
 use std::{
@@ -21,13 +22,14 @@ impl Poller {
         bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         poll_interval: time::Duration,
+        desc: descriptors::InheritanceDescriptor,
     ) -> Poller {
         let shutdown = sync::Arc::from(atomic::AtomicBool::from(false));
         let handle = thread::Builder::new()
             .name("Bitcoin poller".to_string())
             .spawn({
                 let shutdown = shutdown.clone();
-                move || looper(bit, db, shutdown, poll_interval)
+                move || looper(bit, db, shutdown, poll_interval, desc)
             })
             .expect("Must not fail");
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -627,6 +627,7 @@ mod tests {
             block_time: None,
             amount: bitcoin::Amount::from_sat(100_000),
             derivation_index: bip32::ChildNumber::from(13),
+            is_change: false,
             spend_txid: None,
             spend_block: None,
         }]);
@@ -721,6 +722,7 @@ mod tests {
                 block_time: None,
                 amount: bitcoin::Amount::from_sat(100_000),
                 derivation_index: bip32::ChildNumber::from(13),
+                is_change: false,
                 spend_txid: None,
                 spend_block: None,
             },
@@ -730,6 +732,7 @@ mod tests {
                 block_time: None,
                 amount: bitcoin::Amount::from_sat(115_680),
                 derivation_index: bip32::ChildNumber::from(34),
+                is_change: false,
                 spend_txid: None,
                 spend_block: None,
             },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -172,7 +172,9 @@ fn serializable_size<T: bitcoin::consensus::Encodable + ?Sized>(t: &T) -> u64 {
 impl DaemonControl {
     // Get the descriptor at this derivation index
     fn derived_desc(&self, index: bip32::ChildNumber) -> descriptors::DerivedInheritanceDescriptor {
-        self.config.main_descriptor.derive(index, &self.secp)
+        self.config
+            .main_descriptor
+            .derive_receive(index, &self.secp)
     }
 }
 
@@ -201,9 +203,7 @@ impl DaemonControl {
         // TODO: should we wrap around instead of failing?
         db_conn.increment_derivation_index(&self.secp);
         let address = self
-            .config
-            .main_descriptor
-            .derive(index, &self.secp)
+            .derived_desc(index)
             .address(self.config.bitcoin_config.network);
         GetAddressResult { address }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -572,7 +572,7 @@ mod tests {
         assert_eq!(
             addr,
             bitcoin::Address::from_str(
-                "bc1qgudekhcrejgtlx3yhlvdul7t4q76e5lhm0vtcsndxs6aslh4r9jsqkqhwu"
+                "bc1q9ksrc647hx8zp2cewl8p5f487dgux3777yees8rjcx46t4daqzzqt7yga8"
             )
             .unwrap()
         );

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -200,9 +200,9 @@ impl DaemonControl {
     /// whether it was actually used.
     pub fn get_new_address(&self) -> GetAddressResult {
         let mut db_conn = self.db.connection();
-        let index = db_conn.derivation_index();
+        let index = db_conn.receive_index();
         // TODO: should we wrap around instead of failing?
-        db_conn.increment_derivation_index(&self.secp);
+        db_conn.increment_receive_index(&self.secp);
         let address = self
             .derived_desc(index)
             .address(self.config.bitcoin_config.network);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -174,7 +174,8 @@ impl DaemonControl {
     fn derived_desc(&self, index: bip32::ChildNumber) -> descriptors::DerivedInheritanceDescriptor {
         self.config
             .main_descriptor
-            .derive_receive(index, &self.secp)
+            .receive_descriptor()
+            .derive(index, &self.secp)
     }
 }
 
@@ -487,7 +488,7 @@ impl DaemonControl {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetInfoDescriptors {
-    pub main: descriptors::InheritanceDescriptor,
+    pub main: descriptors::MultipathDescriptor,
 }
 
 /// Information about the daemon

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use crate::descriptors::InheritanceDescriptor;
 
 use std::{net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
 
-use miniscript::{bitcoin::Network, DescriptorPublicKey, ForEachKey};
+use miniscript::bitcoin::Network;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -203,14 +203,7 @@ impl Config {
             Network::Bitcoin => Network::Bitcoin,
             _ => Network::Testnet,
         };
-        let unexpected_net = self.main_descriptor.as_inner().for_each_key(|xpub| {
-            if let DescriptorPublicKey::XPub(xpub) = xpub {
-                xpub.xkey.network != expected_network
-            } else {
-                false
-            }
-        });
-        if unexpected_net {
+        if !self.main_descriptor.all_xpubs_net_is(expected_network) {
             return Err(ConfigError::Unexpected(format!(
                 "Our bitcoin network is {} but one xpub is not for network {}",
                 self.bitcoin_config.network, expected_network

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,7 +228,7 @@ mod tests {
             data_dir = "/home/wizardsardine/custom/folder/"
             daemon = false
             log_level = "debug"
-            main_descriptor = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))#y5wcna2d"
+            main_descriptor = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))#5f6qd0d9"
 
             [bitcoin_config]
             network = "bitcoin"
@@ -245,7 +245,7 @@ mod tests {
             data_dir = '/home/wizardsardine/custom/folder/'
             daemon = false
             log_level = 'TRACE'
-            main_descriptor = 'wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))#y5wcna2d'
+            main_descriptor = 'wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))#5f6qd0d9'
 
             [bitcoin_config]
             network = 'bitcoin'
@@ -266,7 +266,7 @@ mod tests {
             log_level = "trace"
             data_dir = "/home/wizardsardine/custom/folder/"
 
-            main_descriptor = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))#y5wcna2e"
+            main_descriptor = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))#y5wcna2e"
 
             [bitcoin_config]
             network = "bitcoin"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::descriptors::InheritanceDescriptor;
+use crate::descriptors::MultipathDescriptor;
 
 use std::{net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
 
@@ -92,7 +92,7 @@ pub struct Config {
         deserialize_with = "deserialize_fromstr",
         serialize_with = "serialize_to_string"
     )]
-    pub main_descriptor: InheritanceDescriptor,
+    pub main_descriptor: MultipathDescriptor,
     /// Settings for the Bitcoin interface
     pub bitcoin_config: BitcoinConfig,
     /// Settings specific to bitcoind as the Bitcoin interface
@@ -113,7 +113,7 @@ pub enum ConfigError {
     DatadirNotFound,
     FileNotFound,
     ReadingFile(String),
-    UnexpectedDescriptor(Box<InheritanceDescriptor>),
+    UnexpectedDescriptor(Box<MultipathDescriptor>),
     Unexpected(String),
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -45,9 +45,13 @@ pub trait DatabaseConnection {
     /// Update our best chain seen.
     fn update_tip(&mut self, tip: &BlockChainTip);
 
-    fn derivation_index(&mut self) -> bip32::ChildNumber;
+    fn receive_index(&mut self) -> bip32::ChildNumber;
 
-    fn increment_derivation_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
+    fn change_index(&mut self) -> bip32::ChildNumber;
+
+    fn increment_receive_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
+
+    fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
 
     /// Get the derivation index for this address, as well as whether this address is change.
     fn derivation_index_by_address(
@@ -114,12 +118,20 @@ impl DatabaseConnection for SqliteConn {
         self.update_tip(tip)
     }
 
-    fn derivation_index(&mut self) -> bip32::ChildNumber {
+    fn receive_index(&mut self) -> bip32::ChildNumber {
         self.db_wallet().deposit_derivation_index
     }
 
-    fn increment_derivation_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
-        self.increment_derivation_index(secp)
+    fn change_index(&mut self) -> bip32::ChildNumber {
+        self.db_wallet().change_derivation_index
+    }
+
+    fn increment_receive_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
+        self.increment_deposit_index(secp)
+    }
+
+    fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
+        self.increment_change_index(secp)
     }
 
     fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -240,7 +240,7 @@ impl SqliteConn {
             let next_la_index = next_index + LOOK_AHEAD_LIMIT - 1;
             let next_la_address = db_wallet
                 .main_descriptor
-                .derive(next_la_index.into(), secp)
+                .derive_receive(next_la_index.into(), secp)
                 .address(network);
             db_tx
                 .execute(
@@ -714,7 +714,7 @@ mod tests {
             // There is the index for the first index
             let addr = options
                 .main_descriptor
-                .derive(0.into(), &secp)
+                .derive_receive(0.into(), &secp)
                 .address(options.bitcoind_network);
             let db_addr = conn.db_address(&addr).unwrap();
             assert_eq!(db_addr.derivation_index, 0.into());
@@ -722,7 +722,7 @@ mod tests {
             // There is the index for the 199th index (look-ahead limit)
             let addr = options
                 .main_descriptor
-                .derive(199.into(), &secp)
+                .derive_receive(199.into(), &secp)
                 .address(options.bitcoind_network);
             let db_addr = conn.db_address(&addr).unwrap();
             assert_eq!(db_addr.derivation_index, 199.into());
@@ -730,7 +730,7 @@ mod tests {
             // And not for the 200th one.
             let addr = options
                 .main_descriptor
-                .derive(200.into(), &secp)
+                .derive_receive(200.into(), &secp)
                 .address(options.bitcoind_network);
             assert!(conn.db_address(&addr).is_none());
 

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -288,14 +288,15 @@ impl SqliteConn {
             for coin in coins {
                 let deriv_index: u32 = coin.derivation_index.into();
                 db_tx.execute(
-                    "INSERT INTO coins (wallet_id, txid, vout, amount_sat, derivation_index) \
-                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                    "INSERT INTO coins (wallet_id, txid, vout, amount_sat, derivation_index, is_change) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                     rusqlite::params![
                         WALLET_ID,
                         coin.outpoint.txid.to_vec(),
                         coin.outpoint.vout,
                         coin.amount.to_sat(),
                         deriv_index,
+                        coin.is_change,
                     ],
                 )?;
             }
@@ -607,6 +608,7 @@ mod tests {
                 block_time: None,
                 amount: bitcoin::Amount::from_sat(98765),
                 derivation_index: bip32::ChildNumber::from_normal_idx(10).unwrap(),
+                is_change: false,
                 spend_txid: None,
                 spend_block: None,
             };
@@ -618,7 +620,7 @@ mod tests {
             assert_eq!(coins.len(), 1);
             assert_eq!(coins[0].outpoint, coin_a.outpoint);
 
-            // Add a second one, we'll get both.
+            // Add a second one (this one is change), we'll get both.
             let coin_b = Coin {
                 outpoint: bitcoin::OutPoint::from_str(
                     "61db3e276b095e5b05f1849dd6bfffb4e7e5ec1c4a4210099b98fce01571936f:12",
@@ -628,6 +630,7 @@ mod tests {
                 block_time: None,
                 amount: bitcoin::Amount::from_sat(1111),
                 derivation_index: bip32::ChildNumber::from_normal_idx(103).unwrap(),
+                is_change: true,
                 spend_txid: None,
                 spend_block: None,
             };
@@ -802,6 +805,7 @@ mod tests {
                     block_time: None,
                     amount: bitcoin::Amount::from_sat(98765),
                     derivation_index: bip32::ChildNumber::from_normal_idx(10).unwrap(),
+                    is_change: false,
                     spend_txid: None,
                     spend_block: None,
                 },
@@ -814,6 +818,7 @@ mod tests {
                     block_time: Some(1_111_899),
                     amount: bitcoin::Amount::from_sat(98765),
                     derivation_index: bip32::ChildNumber::from_normal_idx(100).unwrap(),
+                    is_change: false,
                     spend_txid: None,
                     spend_block: None,
                 },
@@ -826,6 +831,7 @@ mod tests {
                     block_time: Some(1_121_899),
                     amount: bitcoin::Amount::from_sat(98765),
                     derivation_index: bip32::ChildNumber::from_normal_idx(1000).unwrap(),
+                    is_change: false,
                     spend_txid: Some(
                         bitcoin::Txid::from_str(
                             "0c62a990d20d54429e70859292e82374ba6b1b951a3ab60f26bb65fee5724ff7",
@@ -846,6 +852,7 @@ mod tests {
                     block_time: Some(1_131_899),
                     amount: bitcoin::Amount::from_sat(98765),
                     derivation_index: bip32::ChildNumber::from_normal_idx(10000).unwrap(),
+                    is_change: false,
                     spend_txid: None,
                     spend_block: None,
                 },
@@ -858,6 +865,7 @@ mod tests {
                     block_time: Some(1_134_899),
                     amount: bitcoin::Amount::from_sat(98765),
                     derivation_index: bip32::ChildNumber::from_normal_idx(100000).unwrap(),
+                    is_change: false,
                     spend_txid: Some(
                         bitcoin::Txid::from_str(
                             "7477017f992cdc7ba08acafb77cb3b5bc0f42ac340d3e1e1da0785bdda20d5f6",

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -484,7 +484,7 @@ mod tests {
     use bitcoin::{hashes::Hash, util::bip32};
 
     fn dummy_options() -> FreshDbOptions {
-        let desc_str = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))#y5wcna2d";
+        let desc_str = "wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))#5f6qd0d9";
         let main_descriptor = InheritanceDescriptor::from_str(desc_str).unwrap();
         FreshDbOptions {
             bitcoind_network: bitcoin::Network::Bitcoin,
@@ -533,7 +533,7 @@ mod tests {
             .to_string()
             .contains("Database was created for network");
         fs::remove_file(&db_path).unwrap();
-        let other_desc_str = "wsh(andor(pk(tpubDExU4YLJkyQ9RRbVScQq2brFxWWha7WmAUByPWyaWYwmcTv3Shx8aHp6mVwuE5n4TeM4z5DTWGf2YhNPmXtfvyr8cUDVvA3txdrFnFgNdF7/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))";
+        let other_desc_str = "wsh(andor(pk(tpubDExU4YLJkyQ9RRbVScQq2brFxWWha7WmAUByPWyaWYwmcTv3Shx8aHp6mVwuE5n4TeM4z5DTWGf2YhNPmXtfvyr8cUDVvA3txdrFnFgNdF7/<0;1>/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))";
         let other_desc = InheritanceDescriptor::from_str(other_desc_str).unwrap();
         let db = SqliteDb::new(db_path.clone(), Some(options.clone()), &secp).unwrap();
         db.sanity_check(bitcoin::Network::Bitcoin, &other_desc)

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -27,7 +27,8 @@ CREATE TABLE wallets (
     id INTEGER PRIMARY KEY NOT NULL,
     timestamp INTEGER NOT NULL,
     main_descriptor TEXT NOT NULL,
-    deposit_derivation_index INTEGER NOT NULL
+    deposit_derivation_index INTEGER NOT NULL,
+    change_derivation_index INTEGER NOT NULL
 );
 
 /* Our (U)TxOs.
@@ -107,6 +108,7 @@ pub struct DbWallet {
     pub timestamp: u32,
     pub main_descriptor: MultipathDescriptor,
     pub deposit_derivation_index: bip32::ChildNumber,
+    pub change_derivation_index: bip32::ChildNumber,
 }
 
 impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
@@ -122,12 +124,15 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
 
         let der_idx: u32 = row.get(3)?;
         let deposit_derivation_index = bip32::ChildNumber::from(der_idx);
+        let der_idx: u32 = row.get(4)?;
+        let change_derivation_index = bip32::ChildNumber::from(der_idx);
 
         Ok(DbWallet {
             id,
             timestamp,
             main_descriptor,
             deposit_derivation_index,
+            change_derivation_index,
         })
     }
 }

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -57,7 +57,8 @@ CREATE TABLE coins (
  * we can get the derivation index from the parent descriptor from bitcoind.
  */
 CREATE TABLE addresses (
-    address TEXT NOT NULL UNIQUE,
+    receive_address TEXT NOT NULL UNIQUE,
+    change_address TEXT NOT NULL UNIQUE,
     derivation_index INTEGER NOT NULL UNIQUE
 );
 
@@ -195,7 +196,8 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbAddress {
-    pub address: bitcoin::Address,
+    pub receive_address: bitcoin::Address,
+    pub change_address: bitcoin::Address,
     pub derivation_index: bip32::ChildNumber,
 }
 
@@ -203,15 +205,21 @@ impl TryFrom<&rusqlite::Row<'_>> for DbAddress {
     type Error = rusqlite::Error;
 
     fn try_from(row: &rusqlite::Row) -> Result<Self, Self::Error> {
-        let address: String = row.get(0)?;
-        let address = bitcoin::Address::from_str(&address).expect("We only store valid addresses");
+        let receive_address: String = row.get(0)?;
+        let receive_address =
+            bitcoin::Address::from_str(&receive_address).expect("We only store valid addresses");
 
-        let derivation_index: u32 = row.get(1)?;
+        let change_address: String = row.get(1)?;
+        let change_address =
+            bitcoin::Address::from_str(&change_address).expect("We only store valid addresses");
+
+        let derivation_index: u32 = row.get(2)?;
         let derivation_index = bip32::ChildNumber::from(derivation_index);
         assert!(derivation_index.is_normal());
 
         Ok(DbAddress {
-            address,
+            receive_address,
+            change_address,
             derivation_index,
         })
     }

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -1,4 +1,4 @@
-use crate::descriptors::InheritanceDescriptor;
+use crate::descriptors::MultipathDescriptor;
 
 use std::{convert::TryFrom, str::FromStr};
 
@@ -103,7 +103,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbTip {
 pub struct DbWallet {
     pub id: i64,
     pub timestamp: u32,
-    pub main_descriptor: InheritanceDescriptor,
+    pub main_descriptor: MultipathDescriptor,
     pub deposit_derivation_index: bip32::ChildNumber,
 }
 
@@ -115,7 +115,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
         let timestamp = row.get(1)?;
 
         let desc_str: String = row.get(2)?;
-        let main_descriptor = InheritanceDescriptor::from_str(&desc_str)
+        let main_descriptor = MultipathDescriptor::from_str(&desc_str)
             .expect("Insane database: can't parse deposit descriptor");
 
         let der_idx: u32 = row.get(3)?;

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -98,7 +98,7 @@ pub fn create_fresh_db(
         // TODO: have this as a helper in descriptors.rs
         let address = options
             .main_descriptor
-            .derive(index.into(), secp)
+            .derive_receive(index.into(), secp)
             .address(options.bitcoind_network);
         query += &format!(
             "INSERT INTO addresses (address, derivation_index) VALUES (\"{}\", {});\n",

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -98,7 +98,8 @@ pub fn create_fresh_db(
         // TODO: have this as a helper in descriptors.rs
         let address = options
             .main_descriptor
-            .derive_receive(index.into(), secp)
+            .receive_descriptor()
+            .derive(index.into(), secp)
             .address(options.bitcoind_network);
         query += &format!(
             "INSERT INTO addresses (address, derivation_index) VALUES (\"{}\", {});\n",

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -1,8 +1,11 @@
-use crate::database::sqlite::{schema::SCHEMA, FreshDbOptions, SqliteDbError, DB_VERSION};
+use crate::database::sqlite::{
+    schema::{DbWallet, SCHEMA},
+    FreshDbOptions, SqliteDbError, DB_VERSION,
+};
 
 use std::{convert::TryInto, fs, path, time};
 
-use miniscript::bitcoin::secp256k1;
+use miniscript::bitcoin::{self, secp256k1};
 
 pub const LOOK_AHEAD_LIMIT: u32 = 200;
 
@@ -123,14 +126,42 @@ pub fn create_fresh_db(
             rusqlite::params![options.bitcoind_network.to_string()],
         )?;
         tx.execute(
-            "INSERT INTO wallets (timestamp, main_descriptor, deposit_derivation_index) \
-                     VALUES (?1, ?2, ?3)",
-            rusqlite::params![timestamp, options.main_descriptor.to_string(), 0,],
+            "INSERT INTO wallets (timestamp, main_descriptor, deposit_derivation_index, change_derivation_index) \
+                     VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![timestamp, options.main_descriptor.to_string(), 0, 0],
         )?;
         tx.execute_batch(&query)?;
 
         Ok(())
     })?;
+
+    Ok(())
+}
+
+/// Insert the deposit and change addresses for this index in the address->index mapping table
+pub fn populate_address_mapping(
+    db_tx: &rusqlite::Transaction,
+    db_wallet: &DbWallet,
+    next_index: u32,
+    network: bitcoin::Network,
+    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+) -> rusqlite::Result<()> {
+    // Update the address to derivation index mapping.
+    let next_la_index = next_index + LOOK_AHEAD_LIMIT - 1;
+    let next_receive_address = db_wallet
+        .main_descriptor
+        .receive_descriptor()
+        .derive(next_la_index.into(), secp)
+        .address(network);
+    let next_change_address = db_wallet
+        .main_descriptor
+        .change_descriptor()
+        .derive(next_la_index.into(), secp)
+        .address(network);
+    db_tx.execute(
+            "INSERT INTO addresses (receive_address, change_address, derivation_index) VALUES (?1, ?2, ?3)",
+            rusqlite::params![next_receive_address.to_string(), next_change_address.to_string(), next_la_index],
+        )?;
 
     Ok(())
 }

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -95,15 +95,19 @@ pub fn create_fresh_db(
     // necessarily 0.
     let mut query = String::with_capacity(100 * LOOK_AHEAD_LIMIT as usize);
     for index in 0..LOOK_AHEAD_LIMIT {
-        // TODO: have this as a helper in descriptors.rs
-        let address = options
+        let receive_address = options
             .main_descriptor
             .receive_descriptor()
             .derive(index.into(), secp)
             .address(options.bitcoind_network);
+        let change_address = options
+            .main_descriptor
+            .change_descriptor()
+            .derive(index.into(), secp)
+            .address(options.bitcoind_network);
         query += &format!(
-            "INSERT INTO addresses (address, derivation_index) VALUES (\"{}\", {});\n",
-            address, index
+            "INSERT INTO addresses (receive_address, change_address, derivation_index) VALUES (\"{}\", \"{}\", {});\n",
+            receive_address, change_address, index
         );
     }
 

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -9,7 +9,8 @@ use miniscript::{
     descriptor, hash256,
     miniscript::{decode::Terminal, Miniscript},
     policy::{Liftable, Semantic as SemanticPolicy},
-    translate_hash_clone, MiniscriptKey, ScriptContext, ToPublicKey, TranslatePk, Translator,
+    translate_hash_clone, ForEachKey, MiniscriptKey, ScriptContext, ToPublicKey, TranslatePk,
+    Translator,
 };
 
 use std::{collections::BTreeMap, convert::TryFrom, error, fmt, str, sync};
@@ -315,8 +316,15 @@ impl InheritanceDescriptor {
         )))
     }
 
-    pub fn as_inner(&self) -> &descriptor::Descriptor<descriptor::DescriptorPublicKey> {
-        &self.0
+    /// Whether all xpubs contained in this descriptor are for the passed expected network.
+    pub fn all_xpubs_net_is(&self, expected_net: bitcoin::Network) -> bool {
+        self.0.for_each_key(|xpub| {
+            if let descriptor::DescriptorPublicKey::XPub(xpub) = xpub {
+                xpub.xkey.network == expected_net
+            } else {
+                false
+            }
+        })
     }
 
     /// Derive this descriptor at a given index.

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -263,6 +263,12 @@ impl str::FromStr for InheritanceDescriptor {
     }
 }
 
+impl PartialEq<descriptor::Descriptor<descriptor::DescriptorPublicKey>> for InheritanceDescriptor {
+    fn eq(&self, other: &descriptor::Descriptor<descriptor::DescriptorPublicKey>) -> bool {
+        self.0.eq(other)
+    }
+}
+
 impl InheritanceDescriptor {
     pub fn new(
         owner_key: descriptor::DescriptorPublicKey,

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -327,11 +327,11 @@ impl InheritanceDescriptor {
         })
     }
 
-    /// Derive this descriptor at a given index.
+    /// Derive this descriptor at a given index for a receiving address.
     ///
     /// # Panics
     /// - If the given index is hardened.
-    pub fn derive(
+    pub fn derive_receive(
         &self,
         index: bip32::ChildNumber,
         secp: &secp256k1::Secp256k1<impl secp256k1::Verification>,
@@ -504,7 +504,7 @@ mod tests {
     fn inheritance_descriptor_derivation() {
         let secp = secp256k1::Secp256k1::verification_only();
         let desc = InheritanceDescriptor::from_str("wsh(andor(pk(tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/*),older(10000),pk(tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/*)))#y5wcna2d").unwrap();
-        let der_desc = desc.derive(11.into(), &secp);
+        let der_desc = desc.derive_receive(11.into(), &secp);
         assert_eq!(
             "bc1qvjzcg25nsxmfccct0txjvljxjwn68htkrw57jqmjhfzvhyd2z4msc74w65",
             der_desc.address(bitcoin::Network::Bitcoin).to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,8 +600,8 @@ mod tests {
         // Create a dummy config with this bitcoind
         let desc_str = "wsh(andor(pk(xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*),older(10000),pk(xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*)))#yudtr0k5";
         let desc = MultipathDescriptor::from_str(desc_str).unwrap();
-        let receive_desc = desc.receive_descriptor();
-        let change_desc = desc.change_descriptor();
+        let receive_desc = desc.receive_descriptor().clone();
+        let change_desc = desc.change_descriptor().clone();
         let config = Config {
             bitcoin_config,
             bitcoind_config: Some(bitcoind_config),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,7 @@ impl DaemonHandle {
             bit.clone(),
             db.clone(),
             config.bitcoin_config.poll_interval_secs,
+            config.main_descriptor.clone(),
         );
 
         // Finally, set up the API.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{BitcoinConfig, BitcoindConfig},
-        descriptors::InheritanceDescriptor,
+        descriptors::MultipathDescriptor,
         testutils::*,
     };
 
@@ -599,7 +599,7 @@ mod tests {
 
         // Create a dummy config with this bitcoind
         let desc_str = "wsh(andor(pk(xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*),older(10000),pk(xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*)))#yudtr0k5";
-        let desc = InheritanceDescriptor::from_str(desc_str).unwrap();
+        let desc = MultipathDescriptor::from_str(desc_str).unwrap();
         let receive_desc = desc.receive_descriptor();
         let change_desc = desc.change_descriptor();
         let config = Config {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -187,7 +187,10 @@ impl DatabaseConnection for DummyDbConn {
         }
     }
 
-    fn derivation_index_by_address(&mut self, _: &bitcoin::Address) -> Option<bip32::ChildNumber> {
+    fn derivation_index_by_address(
+        &mut self,
+        _: &bitcoin::Address,
+    ) -> Option<(bip32::ChildNumber, bool)> {
         None
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -47,7 +47,7 @@ impl BitcoinInterface for DummyBitcoind {
     fn received_coins(
         &self,
         _: &BlockChainTip,
-        _: &descriptors::InheritanceDescriptor,
+        _: &[descriptors::InheritanceDescriptor],
     ) -> Vec<UTxO> {
         Vec::new()
     }
@@ -274,8 +274,8 @@ impl DummyMinisafe {
             poll_interval_secs: time::Duration::from_secs(2),
         };
 
-        let owner_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/*").unwrap();
-        let heir_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/*").unwrap();
+        let owner_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*").unwrap();
+        let heir_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*").unwrap();
         let desc =
             crate::descriptors::InheritanceDescriptor::new(owner_key, heir_key, 10_000).unwrap();
         let config = Config {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -277,7 +277,7 @@ impl DummyMinisafe {
         let owner_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*").unwrap();
         let heir_key = descriptor::DescriptorPublicKey::from_str("xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*").unwrap();
         let desc =
-            crate::descriptors::InheritanceDescriptor::new(owner_key, heir_key, 10_000).unwrap();
+            crate::descriptors::MultipathDescriptor::new(owner_key, heir_key, 10_000).unwrap();
         let config = Config {
             bitcoin_config,
             bitcoind_config: None,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -2,7 +2,7 @@ use crate::{
     bitcoin::{BitcoinError, BitcoinInterface, BlockChainTip, UTxO},
     config::{BitcoinConfig, Config},
     database::{Coin, DatabaseConnection, DatabaseInterface, SpendBlock},
-    DaemonHandle,
+    descriptors, DaemonHandle,
 };
 
 use std::{collections::HashMap, env, fs, io, path, process, str::FromStr, sync, thread, time};
@@ -44,7 +44,11 @@ impl BitcoinInterface for DummyBitcoind {
         true
     }
 
-    fn received_coins(&self, _: &BlockChainTip) -> Vec<UTxO> {
+    fn received_coins(
+        &self,
+        _: &BlockChainTip,
+        _: &descriptors::InheritanceDescriptor,
+    ) -> Vec<UTxO> {
         Vec::new()
     }
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -121,7 +121,7 @@ def minisafed(bitcoind, directory):
 
     owner_hd = BIP32.from_seed(os.urandom(32), network="test")
     owner_xpub = owner_hd.get_xpub()
-    main_desc = Descriptor.from_str(f"wsh(or_d(pk({owner_xpub}/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/*),older(65000))))")
+    main_desc = Descriptor.from_str(f"wsh(or_d(pk({owner_xpub}/<0;1>/*),and_v(v:pkh(tpubD9vQiBdDxYzU4cVFtApWj4devZrvcfWaPXX1zHdDc7GPfUsDKqGnbhraccfm7BAXgRgUbVQUV2v2o4NitjGEk7hpbuP85kvBrD4ahFDtNBJ/<0;1>/*),older(65000))))")
 
     minisafed = Minisafed(
         datadir,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ pytest-timeout==1.3.4
 ephemeral_port_reserve==1.1.1
 
 bip32~=3.0
-bip380==0.0.3
+https://github.com/darosior/python-bip380/archive/f25eb2add9a5d461e382635231a5f971652fc8e1.zip

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -88,6 +88,7 @@ def test_create_spend(minisafed, bitcoind):
         bitcoind.generate_block(1, wait_for_mempool=txid)
     txid = bitcoind.rpc.sendtoaddress(addr, 0.3556)
     bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 16)
 
     # Stop the daemon, should be a no-op
     minisafed.stop()

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -1,0 +1,55 @@
+from fixtures import *
+from test_framework.serializations import PSBT
+from test_framework.utils import wait_for
+
+
+def test_spend_change(minisafed, bitcoind):
+    """We can spend a coin that was received on a change address."""
+    # Receive a coin on a receive address
+    addr = minisafed.rpc.getnewaddress()["address"]
+    txid = bitcoind.rpc.sendtoaddress(addr, 0.01)
+    bitcoind.generate_block(1, wait_for_mempool=txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 1)
+
+    # Create a transaction that will spend this coin to 1) one of our receive
+    # addresses 2) an external address 3) one of our change addresses.
+    outpoints = [c["outpoint"] for c in minisafed.rpc.listcoins()["coins"]]
+    destinations = {
+        bitcoind.rpc.getnewaddress(): 100_000,
+        minisafed.rpc.getnewaddress()["address"]: 100_000,
+    }
+    res = minisafed.rpc.createspend(outpoints, destinations, 2)
+    assert "psbt" in res
+
+    # The transaction must contain a change output.
+    spend_psbt = PSBT.from_base64(res["psbt"])
+    assert len(spend_psbt.o) == 3
+    assert len(spend_psbt.tx.vout) == 3
+
+    # Sign and broadcast this first Spend transaction.
+    signed_psbt = minisafed.sign_psbt(spend_psbt)
+    minisafed.rpc.updatespend(signed_psbt.to_base64())
+    spend_txid = signed_psbt.tx.txid().hex()
+    minisafed.rpc.broadcastspend(spend_txid)
+    bitcoind.generate_block(1, wait_for_mempool=spend_txid)
+    wait_for(lambda: len(minisafed.rpc.listcoins()["coins"]) == 3)
+
+    # Now create a new transaction that spends the change output as well as
+    # the output sent to the receive address.
+    outpoints = [
+        c["outpoint"]
+        for c in minisafed.rpc.listcoins()["coins"]
+        if c["spend_info"] is None
+    ]
+    destinations = {
+        bitcoind.rpc.getnewaddress(): 100_000,
+    }
+    res = minisafed.rpc.createspend(outpoints, destinations, 2)
+    spend_psbt = PSBT.from_base64(res["psbt"])
+
+    # We can sign and broadcast it.
+    signed_psbt = minisafed.sign_psbt(spend_psbt)
+    minisafed.rpc.updatespend(signed_psbt.to_base64())
+    spend_txid = signed_psbt.tx.txid().hex()
+    minisafed.rpc.broadcastspend(spend_txid)
+    bitcoind.generate_block(1, wait_for_mempool=spend_txid)


### PR DESCRIPTION
This fixes #18 by implementing the de-facto standard of using a `/0/*` keychain for receiving addresses and a `/1/*` keychain for change addresses. Note that once we'll have multisig, reusing addresses will still be possible since wallet don't share the same "next derivation index".

In order to avoid forcing the user to configure and backup two almost identical descriptors, we make use of the recently proposed BIP389 (https://github.com/bitcoin/bips/pull/1354). In order to prevent as much as possible introducing a backward incompatibility in the configuration file after the first release, we restrict the usage of multipath descriptors to `<0;1>` here.
We now derive public keys from `xpub/0/*` and `xpub/1/*` while we were previously deriving them from `xpub/*`.

This triggered a pretty invasive refactoring, as most parts of the codebase had to be updated to support the new change/receive separation (even the functional test miniscript dependency had to be updated, see https://github.com/darosior/python-bip380/pull/21).
Broadly, this:
1. Update our Miniscript dependency to my upstream PR (https://github.com/rust-bitcoin/rust-miniscript/pull/470) rebased on top of the 8.0.0 release.
2. Updates the descriptors module to handle somewhat safely the multipath descriptors (to avoid mixing up the single, multi, and derived descriptors).
3. Makes a multipath descriptor mandatory in the configuration file.
4. Updates the Bitcoin backend poller aware of descriptors for which to track coins.
   - Necessarily this updates the bitcoind implementation to import two descriptors
5. Record in database whether a coin was for the change or receive descriptor, in addition to its derivation index