### PR TITLE
Block chain rescanning for our descriptor(s)

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -43,13 +43,14 @@ This command does not take any parameter for now.
 
 #### Response
 
-| Field                | Type    | Description                                                                                  |
-| -------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `version`            | string  | Version following the [SimVer](http://www.simver.org/) format                                |
-| `network`            | string  | Answer can be `mainnet`, `testnet`, `regtest`                                                |
-| `blockheight`        | integer | The block height we are synced at.                                                           |
-| `sync`               | float   | The synchronization progress as percentage (`0 < sync < 1`)                                  |
-| `descriptors`        | object  | Object with the name of the descriptor as key and the descriptor string as value             |
+| Field                | Type    | Description                                                                                        |
+| -------------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `version`            | string        | Version following the [SimVer](http://www.simver.org/) format                                |
+| `network`            | string        | Answer can be `mainnet`, `testnet`, `regtest`                                                |
+| `blockheight`        | integer       | The block height we are synced at.                                                           |
+| `sync`               | float         | The synchronization progress as percentage (`0 < sync < 1`)                                  |
+| `descriptors`        | object        | Object with the name of the descriptor as key and the descriptor string as value             |
+| `rescan_progress`    | float or null | Progress of an ongoing rescan as a percentage (between 0 and 1) if there is any              |
 
 ### `getnewaddress`
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -13,6 +13,7 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`listspendtxs`](#listspendtxs)                             | List all stored Spend transactions                   |
 | [`delspendtx`](#delspendtx)                                 | Delete a stored Spend transaction                    |
 | [`broadcastspend`](#broadcastspend)                         | Finalize a stored Spend PSBT, and broadcast it       |
+| [`startrescan`](#startrescan)                               | Start rescanning the block chain from a given date   |
 
 # Reference
 
@@ -192,6 +193,22 @@ This command does not return anything for now.
 | Field    | Type   | Description                                            |
 | -------- | ------ | ------------------------------------------------------ |
 | `txid`   | string | Hex encoded txid of the Spend transaction to broadcast |
+
+#### Response
+
+This command does not return anything for now.
+
+| Field          | Type      | Description                                          |
+| -------------- | --------- | ---------------------------------------------------- |
+
+
+### `startrescan`
+
+#### Request
+
+| Field        | Type   | Description                                            |
+| ------------ | ------ | ------------------------------------------------------ |
+| `timestamp`  | int    | Date to start rescanning from, as a UNIX timestamp     |
 
 #### Response
 

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -219,8 +219,10 @@ impl BitcoinD {
                             Some(simple_http::Error::Timeout)
                             | Some(simple_http::Error::SocketError(_))
                             | Some(simple_http::Error::HttpErrorCode(503)) => {
-                                std::thread::sleep(Duration::from_secs(1));
-                                log::debug!("Retrying RPC request to bitcoind: attempt #{}", i);
+                                if i <= self.retries {
+                                    std::thread::sleep(Duration::from_secs(1));
+                                    log::debug!("Retrying RPC request to bitcoind: attempt #{}", i);
+                                }
                                 error = Some(e);
                             }
                             _ => return Err(e),

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -472,8 +472,18 @@ impl BitcoinD {
                         .try_into()
                         .expect("Range is always an array of size 2")
                 });
+                let timestamp = elem
+                    .get("timestamp")
+                    .and_then(Json::as_u64)
+                    .expect("A valid timestamp is always present")
+                    .try_into()
+                    .expect("timestamp must fit");
 
-                ListDescEntry { desc, range }
+                ListDescEntry {
+                    desc,
+                    range,
+                    timestamp,
+                }
             })
             .collect()
     }
@@ -894,6 +904,7 @@ fn roundup_progress(progress: f64) -> f64 {
 pub struct ListDescEntry {
     pub desc: String,
     pub range: Option<[u32; 2]>,
+    pub timestamp: u32,
 }
 
 /// A 'received' entry in the 'listsinceblock' result.

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -688,11 +688,23 @@ impl BitcoinD {
             .and_then(Json::as_i64)
             .expect("Invalid height in `getblockheader` response: not an i64")
             as i32;
+        let time = res
+            .get("time")
+            .and_then(Json::as_u64)
+            .expect("Invalid timestamp in `getblockheader` response: not an u64")
+            as u32;
+        let median_time_past = res
+            .get("mediantime")
+            .and_then(Json::as_u64)
+            .expect("Invalid median timestamp in `getblockheader` response: not an u64")
+            as u32;
         BlockStats {
             confirmations,
             previous_blockhash,
             height,
             blockhash,
+            time,
+            median_time_past,
         }
     }
 
@@ -853,4 +865,6 @@ pub struct BlockStats {
     pub previous_blockhash: Option<bitcoin::BlockHash>,
     pub blockhash: bitcoin::BlockHash,
     pub height: i32,
+    pub time: u32,
+    pub median_time_past: u32,
 }

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -679,12 +679,14 @@ impl BitcoinD {
         let previous_blockhash = res
             .get("previousblockhash")
             .and_then(Json::as_str)
-            .and_then(|s| bitcoin::BlockHash::from_str(s).ok())
-            .expect("Invalid previousblockhash in `getblockheader` response");
+            .map(|s| {
+                bitcoin::BlockHash::from_str(s)
+                    .expect("Invalid previousblockhash in `getblockheader` response")
+            });
         let height = res
             .get("height")
             .and_then(Json::as_i64)
-            .expect("Invalid height in `getblockheader` response: not an u32")
+            .expect("Invalid height in `getblockheader` response: not an i64")
             as i32;
         BlockStats {
             confirmations,
@@ -848,7 +850,7 @@ impl From<Json> for GetTxRes {
 #[derive(Debug, Clone)]
 pub struct BlockStats {
     pub confirmations: i32,
-    pub previous_blockhash: bitcoin::BlockHash,
+    pub previous_blockhash: Option<bitcoin::BlockHash>,
     pub blockhash: bitcoin::BlockHash,
     pub height: i32,
 }

--- a/src/bitcoin/d/utils.rs
+++ b/src/bitcoin/d/utils.rs
@@ -1,0 +1,350 @@
+use crate::bitcoin::{d::BlockStats, BlockChainTip};
+
+use miniscript::bitcoin;
+
+// As a standalone function to unit test it.
+/// Get the last block of the chain before the given date by performing a binary search.
+pub fn block_before_date<Fh, Fs>(
+    target_timestamp: u32,
+    chain_tip: BlockChainTip,
+    mut get_hash: Fh,
+    mut get_stats: Fs,
+) -> Option<BlockChainTip>
+where
+    Fh: FnMut(i32) -> Option<bitcoin::BlockHash>,
+    Fs: FnMut(bitcoin::BlockHash) -> BlockStats,
+{
+    log::debug!("Looking for the first block before {}", target_timestamp);
+
+    let mut start_height = 0;
+    let mut end_height = chain_tip.height;
+
+    let genesis_stats = get_stats(get_hash(0).expect("Genesis hash"));
+    let tip_stats = get_stats(chain_tip.hash);
+    if !(genesis_stats.time..tip_stats.time).contains(&target_timestamp) {
+        return None;
+    }
+
+    while start_height < end_height {
+        log::debug!("Start: {}, end: {}", start_height, end_height,);
+        let delta = end_height.checked_sub(start_height).unwrap();
+        let current_height = start_height + delta.checked_div(2).unwrap();
+        // We want the last block with a timestamp below, not the first with a higher one.
+        let next_height = current_height.checked_add(1).unwrap();
+        let next_stats = get_stats(get_hash(next_height)?);
+        log::debug!("Current next block: {:?}", next_stats);
+
+        if target_timestamp > next_stats.time {
+            start_height = next_height;
+        } else {
+            assert!(current_height < end_height);
+            end_height = current_height;
+        }
+    }
+
+    // TODO: the timestamps in the chain are not strictly ordered. There could technically be a
+    // timestamp above the target a bit down this height. I think we would be safe by scanning the
+    // last 12 blocks and checking their timestamp is below the target. Would we?
+    log::debug!("Result height: {}", start_height);
+    Some(BlockChainTip {
+        height: start_height,
+        hash: get_hash(start_height)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    // The expected number of seconds in average between two blocks.
+    const EXPECTED_BLOCK_INTERVAL_SECS: u32 = 600;
+
+    // Inefficient dummy implementation of BitcoinD's self.get_block_hash
+    fn get_hash(chain: &[(BlockChainTip, BlockStats)], height: i32) -> Option<bitcoin::BlockHash> {
+        chain
+            .iter()
+            .find(|(tip, _)| tip.height == height)
+            .map(|(tip, _)| tip.hash)
+    }
+
+    // Inefficient dummy implementation of BitcoinD's self.get_block_stats
+    fn get_stats(chain: &[(BlockChainTip, BlockStats)], hash: bitcoin::BlockHash) -> BlockStats {
+        chain
+            .iter()
+            .find(|(tip, _)| tip.hash == hash)
+            .unwrap()
+            .1
+            .clone()
+    }
+
+    macro_rules! bh {
+        ($h_str: literal) => {
+            bitcoin::BlockHash::from_str($h_str).unwrap()
+        };
+    }
+
+    // Create a dummy BlockStats struct with the given time
+    fn create_stats(time: u32) -> BlockStats {
+        // TODO
+        BlockStats {
+            height: 0,
+            confirmations: 0,
+            previous_blockhash: Some(bh!(
+                "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+            )),
+            blockhash: bh!("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+            time,
+            median_time_past: 0,
+        }
+    }
+
+    #[test]
+    fn blk_before_time() {
+        // A timestamp after the tip's
+        let dummy_chain = [
+            (
+                BlockChainTip {
+                    height: 0,
+                    hash: bh!("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+                },
+                create_stats(1231006505),
+            ),
+            (
+                BlockChainTip {
+                    height: 761683,
+                    hash: bh!("0000000000000000000560bb21fbab991fe5f7d9a949eb424f9be3c34a55a54f"),
+                },
+                create_stats(1667558116),
+            ),
+        ];
+        assert!(block_before_date(
+            dummy_chain[0].1.time + 1,
+            dummy_chain[0].0,
+            |h| get_hash(&dummy_chain, h),
+            |h| get_stats(&dummy_chain, h),
+        )
+        .is_none());
+
+        // A timestamp before the genesis
+        let dummy_chain = [
+            (
+                BlockChainTip {
+                    height: 0,
+                    hash: bh!("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+                },
+                create_stats(1231006505),
+            ),
+            (
+                BlockChainTip {
+                    height: 761683,
+                    hash: bh!("0000000000000000000560bb21fbab991fe5f7d9a949eb424f9be3c34a55a54f"),
+                },
+                create_stats(1667558116),
+            ),
+        ];
+        assert!(block_before_date(
+            dummy_chain[0].1.time - 1,
+            dummy_chain[0].0,
+            |h| get_hash(&dummy_chain, h),
+            |h| get_stats(&dummy_chain, h),
+        )
+        .is_none());
+
+        // Simulate and detail a full binary search through a dummy chain.
+        let target_timestamp = 1531006505;
+        let dummy_chain = [
+            // Genesis: will be queried at step 0 (0, 761_683)
+            (
+                BlockChainTip {
+                    height: 0,
+                    hash: bh!("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+                },
+                create_stats(1231006505),
+            ),
+            // Step 1 (0, 761_683): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 380_842,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba3"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 10),
+            ),
+            // Step 4 (380_842, 476_052): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 428_448,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba4"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 9),
+            ),
+            // Step 6 (428_448, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 440_350,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba5"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 8),
+            ),
+            // Step 7 (440_350, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 446_301,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba6"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 7),
+            ),
+            // Step 8 (446_301, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 449_276,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba7"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 6),
+            ),
+            // Step 9 (449_276, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 450_764,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba8"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 5),
+            ),
+            // Step 10 (450_764, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 451_508,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19ba9"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 4),
+            ),
+            // Step 11 (451_508, 452_250): timestamp too low (and equal to the previous one).
+            (
+                BlockChainTip {
+                    height: 451_880,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bab"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 4),
+            ),
+            // Step 12 (451_880, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_066,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bac"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 3),
+            ),
+            // Step 13 (452_066, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_159,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bad"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS * 2),
+            ),
+            // Step 14 (452_159, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_205,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bae"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS),
+            ),
+            // Step 15 (452_205, 452_250): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_228,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19baf"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS),
+            ),
+            // Step 17 (452_228, 452_239): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_234,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb0"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS / 2),
+            ),
+            // Step 18 (452_234, 452_239): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_237,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb1"),
+                },
+                create_stats(target_timestamp - EXPECTED_BLOCK_INTERVAL_SECS / 4),
+            ),
+            // Step 21 (452_237, 452_238): timestamp too low.
+            (
+                BlockChainTip {
+                    height: 452_238,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb2"),
+                },
+                create_stats(target_timestamp - 1),
+            ),
+            // Step 20 (452_237, 452_239): timestamp too high (first block at this timestamp).
+            (
+                BlockChainTip {
+                    height: 452_239,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb3"),
+                },
+                create_stats(target_timestamp),
+            ),
+            // Step 16 (452_228, 452_250): timestamp too high (timestamp don't necessarily
+            // increase per block height).
+            (
+                BlockChainTip {
+                    height: 452_240,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb4"),
+                },
+                create_stats(target_timestamp + 1),
+            ),
+            // Step 5 (428_448, 476_052): timestamp too high (again equal! That's possible).
+            (
+                BlockChainTip {
+                    height: 452_251,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb5"),
+                },
+                create_stats(target_timestamp),
+            ),
+            // Step 3 (380_842, 571_262): timestamp too high (because equal).
+            (
+                BlockChainTip {
+                    height: 476_053,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb6"),
+                },
+                create_stats(target_timestamp),
+            ),
+            // Step 2 (380_842, 761_683): timestamp too high.
+            (
+                BlockChainTip {
+                    height: 571_263,
+                    hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb7"),
+                },
+                create_stats(target_timestamp + EXPECTED_BLOCK_INTERVAL_SECS),
+            ),
+            // Tip: will be queried at step 0
+            (
+                BlockChainTip {
+                    height: 761_683,
+                    hash: bh!("0000000000000000000560bb21fbab991fe5f7d9a949eb424f9be3c34a55a54f"),
+                },
+                create_stats(1667558116),
+            ),
+        ];
+        assert_eq!(
+            block_before_date(
+                target_timestamp,
+                dummy_chain[dummy_chain.len() - 1].0,
+                |h| get_hash(&dummy_chain, h),
+                |h| get_stats(&dummy_chain, h),
+            )
+            .unwrap(),
+            // Step 21 above
+            BlockChainTip {
+                height: 452_238,
+                hash: bh!("000000000000000005c0655db17fde80f67ff0502a62b7250ed2685619d19bb2"),
+            }
+        );
+    }
+}

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -76,7 +76,11 @@ pub trait BitcoinInterface: Send {
 
     /// Trigger a rescan of the block chain for transactions related to this descriptor since
     /// the given date.
-    fn start_rescan(&self, desc: &descriptors::MultipathDescriptor, timestamp: u32);
+    fn start_rescan(
+        &self,
+        desc: &descriptors::MultipathDescriptor,
+        timestamp: u32,
+    ) -> Result<(), String>;
 
     /// Rescan progress percentage. Between 0 and 1.
     fn rescan_progress(&self) -> Option<f64>;
@@ -283,9 +287,14 @@ impl BitcoinInterface for d::BitcoinD {
         }
     }
 
-    fn start_rescan(&self, desc: &descriptors::MultipathDescriptor, timestamp: u32) {
+    fn start_rescan(
+        &self,
+        desc: &descriptors::MultipathDescriptor,
+        timestamp: u32,
+    ) -> Result<(), String> {
         // FIXME: in theory i think this could potentially fail to actually start the rescan.
-        self.start_rescan(desc, timestamp);
+        self.start_rescan(desc, timestamp)
+            .map_err(|e| e.to_string())
     }
 
     fn rescan_progress(&self) -> Option<f64> {
@@ -357,7 +366,11 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
         self.lock().unwrap().broadcast_tx(tx)
     }
 
-    fn start_rescan(&self, desc: &descriptors::MultipathDescriptor, timestamp: u32) {
+    fn start_rescan(
+        &self,
+        desc: &descriptors::MultipathDescriptor,
+        timestamp: u32,
+    ) -> Result<(), String> {
         self.lock().unwrap().start_rescan(desc, timestamp)
     }
 

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -212,6 +212,54 @@ fn updates(
     log::debug!("Updates done.");
 }
 
+// Check if there is any rescan of the backend ongoing or one that just finished.
+fn rescan_check(
+    bit: &impl BitcoinInterface,
+    db: &impl DatabaseInterface,
+    descs: &[descriptors::InheritanceDescriptor],
+) {
+    log::debug!("Checking the state of an ongoing rescan if there is any");
+    let mut db_conn = db.connection();
+
+    // Check if there is an ongoing rescan. If there isn't and we previously asked for a rescan of
+    // the backend, we treat it as completed.
+    // Upon completion of the rescan from the given timestamp on the backend, we rollback our state
+    // down to the height before this timestamp to rescan everything that happened since then.
+    let rescan_timestamp = db_conn.rescan_timestamp();
+    if let Some(progress) = bit.rescan_progress() {
+        log::info!("Rescan progress: {:.2}%.", progress * 100.0);
+        if rescan_timestamp.is_none() {
+            log::warn!("Backend is rescanning but we didn't ask for it.");
+        }
+    } else if let Some(timestamp) = rescan_timestamp {
+        log::info!("Rescan completed on the backend.");
+        // TODO: we could check if the timestamp of the descriptors in the Bitcoin backend are
+        // truly at the rescan timestamp, and trigger a rescan otherwise. Note however it would be
+        // no use for the bitcoind implementation of the backend, since bitcoind will always set
+        // the timestamp of the descriptors in the wallet first (and therefore consider it as
+        // rescanned from this height even if it aborts the rescan by being stopped).
+        let rescan_tip = match bit.block_before_date(timestamp) {
+            Some(block) => block,
+            None => {
+                log::error!(
+                    "Could not retrieve block height for timestamp '{}'",
+                    timestamp
+                );
+                return;
+            }
+        };
+        db_conn.rollback_tip(&rescan_tip);
+        db_conn.complete_rescan();
+        log::info!(
+            "Rolling back our internal tip to '{}' to update our internal state with past transactions.",
+            rescan_tip
+        );
+        updates(bit, db, descs)
+    } else {
+        log::debug!("No ongoing rescan.");
+    }
+}
+
 // If the database chain tip is NULL (first startup), initialize it.
 fn maybe_initialize_tip(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
     let mut db_conn = db.connection();
@@ -269,5 +317,6 @@ pub fn looper(
         }
 
         updates(&bit, &db, &descs);
+        rescan_check(&bit, &db, &descs);
     }
 }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -150,13 +150,20 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
     // block chain re-organisation. Find the common ancestor between our current chain and
     // the new chain and return that. The caller will take care of rewinding our state.
     log::info!("Block chain reorganization detected. Looking for common ancestor.");
-    let common_ancestor = bit.common_ancestor(current_tip);
-    log::info!(
-        "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
-        common_ancestor,
-        current_tip
-    );
-    TipUpdate::Reorged(common_ancestor)
+    if let Some(common_ancestor) = bit.common_ancestor(current_tip) {
+        log::info!(
+            "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
+            common_ancestor,
+            current_tip
+        );
+        TipUpdate::Reorged(common_ancestor)
+    } else {
+        log::error!(
+            "Failed to get common ancestor for tip '{}'. Starting over.",
+            current_tip
+        );
+        new_tip(bit, current_tip)
+    }
 }
 
 fn updates(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -196,6 +196,9 @@ impl DaemonControl {
         let mut db_conn = self.db.connection();
 
         let blockheight = db_conn.chain_tip().map(|tip| tip.height).unwrap_or(0);
+        let rescan_progress = db_conn
+            .rescan_timestamp()
+            .map(|_| self.bitcoin.rescan_progress().unwrap_or(1.0));
         GetInfoResult {
             version: VERSION.to_string(),
             network: self.config.bitcoin_config.network,
@@ -204,6 +207,7 @@ impl DaemonControl {
             descriptors: GetInfoDescriptors {
                 main: self.config.main_descriptor.clone(),
             },
+            rescan_progress,
         }
     }
 
@@ -535,6 +539,8 @@ pub struct GetInfoResult {
     pub blockheight: i32,
     pub sync: f64,
     pub descriptors: GetInfoDescriptors,
+    /// The progress as a percentage (between 0 and 1) of an ongoing rescan if there is any
+    pub rescan_progress: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,7 +5,7 @@
 mod utils;
 
 use crate::{
-    bitcoin::{BitcoinError, BitcoinInterface},
+    bitcoin::BitcoinInterface,
     database::{Coin, DatabaseInterface},
     descriptors, DaemonControl, VERSION,
 };
@@ -499,10 +499,9 @@ impl DaemonControl {
         // Then, broadcast it (or try to, we never know if we are not going to hit an
         // error at broadcast time).
         let final_tx = spend_psbt.extract_tx();
-        match self.bitcoin.broadcast_tx(&final_tx) {
-            Ok(()) => Ok(()),
-            Err(BitcoinError::Broadcast(e)) => Err(CommandError::TxBroadcast(e)),
-        }
+        self.bitcoin
+            .broadcast_tx(&final_tx)
+            .map_err(CommandError::TxBroadcast)
     }
 
     /// Trigger a rescan of the block chain for transactions involving our main descriptor between

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -53,6 +53,15 @@ pub trait DatabaseConnection {
 
     fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
 
+    /// Get the timestamp at which to start rescaning from, if any.
+    fn rescan_timestamp(&mut self) -> Option<u32>;
+
+    /// Set a timestamp at which to start rescaning the block chain from.
+    fn set_rescan(&mut self, timestamp: u32);
+
+    /// Mark the rescan as complete.
+    fn complete_rescan(&mut self);
+
     /// Get the derivation index for this address, as well as whether this address is change.
     fn derivation_index_by_address(
         &mut self,
@@ -132,6 +141,18 @@ impl DatabaseConnection for SqliteConn {
 
     fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
         self.increment_change_index(secp)
+    }
+
+    fn rescan_timestamp(&mut self) -> Option<u32> {
+        self.db_wallet().rescan_timestamp
+    }
+
+    fn set_rescan(&mut self, timestamp: u32) {
+        self.set_wallet_rescan_timestamp(timestamp)
+    }
+
+    fn complete_rescan(&mut self) {
+        self.complete_wallet_rescan()
     }
 
     fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -159,7 +159,9 @@ impl From<commands::CommandError> for Error {
             | commands::CommandError::InvalidOutputValue(..)
             | commands::CommandError::InsufficientFunds(..)
             | commands::CommandError::UnknownSpend(..)
-            | commands::CommandError::SpendFinalization(..) => {
+            | commands::CommandError::SpendFinalization(..)
+            | commands::CommandError::InsaneRescanTimestamp(..)
+            | commands::CommandError::AlreadyRescanning => {
                 Error::new(ErrorCode::InvalidParams, e.to_string())
             }
             commands::CommandError::SanityCheckFailure(_) => {

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -164,7 +164,8 @@ impl From<commands::CommandError> for Error {
             | commands::CommandError::AlreadyRescanning => {
                 Error::new(ErrorCode::InvalidParams, e.to_string())
             }
-            commands::CommandError::SanityCheckFailure(_) => {
+            commands::CommandError::SanityCheckFailure(_)
+            | commands::CommandError::RescanTrigger(..) => {
                 Error::new(ErrorCode::InternalError, e.to_string())
             }
             commands::CommandError::TxBroadcast(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,10 +516,10 @@ mod tests {
         let net_resp = [
             "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"descriptors\":[{\"desc\":\"".as_bytes(),
             receive_desc.as_bytes(),
-            "\"},".as_bytes(),
+            "\",\"timestamp\":0},".as_bytes(),
             "{\"desc\":\"".as_bytes(),
             change_desc.as_bytes(),
-            "\"}]}}\n".as_bytes(),
+            "\",\"timestamp\":1}]}}\n".as_bytes(),
         ]
         .concat();
         let (mut stream, _) = server.accept().unwrap();

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinError, BitcoinInterface, BlockChainTip, UTxO},
+    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
     config::{BitcoinConfig, Config},
     database::{Coin, DatabaseConnection, DatabaseInterface, SpendBlock},
     descriptors, DaemonHandle,
@@ -71,7 +71,7 @@ impl BitcoinInterface for DummyBitcoind {
         todo!()
     }
 
-    fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), BitcoinError> {
+    fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), String> {
         todo!()
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -266,6 +266,18 @@ impl DatabaseConnection for DummyDbConn {
     fn rollback_tip(&mut self, _: &BlockChainTip) {
         todo!()
     }
+
+    fn rescan_timestamp(&mut self) -> Option<u32> {
+        None
+    }
+
+    fn set_rescan(&mut self, _: u32) {
+        todo!()
+    }
+
+    fn complete_rescan(&mut self) {
+        todo!()
+    }
 }
 
 pub struct DummyMinisafe {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -74,6 +74,22 @@ impl BitcoinInterface for DummyBitcoind {
     fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), BitcoinError> {
         todo!()
     }
+
+    fn start_rescan(&self, _: &descriptors::MultipathDescriptor, _: u32) {
+        todo!()
+    }
+
+    fn rescan_progress(&self) -> Option<f64> {
+        None
+    }
+
+    fn block_before_date(&self, _: u32) -> Option<BlockChainTip> {
+        todo!()
+    }
+
+    fn tip_time(&self) -> u32 {
+        todo!()
+    }
 }
 
 pub struct DummyDb {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -75,7 +75,7 @@ impl BitcoinInterface for DummyBitcoind {
         todo!()
     }
 
-    fn start_rescan(&self, _: &descriptors::MultipathDescriptor, _: u32) {
+    fn start_rescan(&self, _: &descriptors::MultipathDescriptor, _: u32) -> Result<(), String> {
         todo!()
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -67,7 +67,7 @@ impl BitcoinInterface for DummyBitcoind {
         Vec::new()
     }
 
-    fn common_ancestor(&self, _: &BlockChainTip) -> BlockChainTip {
+    fn common_ancestor(&self, _: &BlockChainTip) -> Option<BlockChainTip> {
         todo!()
     }
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,4 +1,8 @@
+import os
 import pytest
+import random
+import shutil
+import time
 
 from fixtures import *
 from test_framework.serializations import PSBT, PSBT_IN_PARTIAL_SIG
@@ -12,6 +16,7 @@ def test_getinfo(minisafed):
     wait_for(lambda: res["blockheight"] == 101)
     assert res["sync"] == 1.0
     assert "main" in res["descriptors"]
+    assert res["rescan_progress"] is None
 
 
 def test_getaddress(minisafed):
@@ -253,3 +258,87 @@ def test_broadcast_spend(minisafed, bitcoind):
     # Now we've signed and stored it, the daemon will take care of finalizing
     # the PSBT before broadcasting the transaction.
     minisafed.rpc.broadcastspend(txid)
+
+
+def test_start_rescan(minisafed, bitcoind):
+    """Test we successfully retrieve all our transactions after losing state by rescanning."""
+    initial_timestamp = int(time.time())
+
+    # Some utility functions to DRY
+    list_coins = lambda: minisafed.rpc.listcoins()["coins"]
+    unspent_coins = lambda: (
+        c for c in minisafed.rpc.listcoins()["coins"] if c["spend_info"] is None
+    )
+    sorted_coins = lambda: sorted(list_coins(), key=lambda c: c["outpoint"])
+
+    def all_spent(coins):
+        unspent = set(c["outpoint"] for c in unspent_coins())
+        for c in coins:
+            if c["outpoint"] in unspent:
+                return False
+        return True
+
+    # We can rescan from one second before the tip timestamp, that's almost a no-op.
+    tip_timestamp = bitcoind.rpc.getblockheader(bitcoind.rpc.getbestblockhash())["time"]
+    minisafed.rpc.startrescan(tip_timestamp - 1)
+    wait_for(lambda: minisafed.rpc.getinfo()["rescan_progress"] is None)
+    # We can't rescan from an insane timestamp though.
+    with pytest.raises(RpcError, match="Insane timestamp.*"):
+        minisafed.rpc.startrescan(tip_timestamp)
+    assert minisafed.rpc.getinfo()["rescan_progress"] is None
+    future_timestamp = tip_timestamp + 60 * 60
+    with pytest.raises(RpcError, match="Insane timestamp.*"):
+        minisafed.rpc.startrescan(future_timestamp)
+    assert minisafed.rpc.getinfo()["rescan_progress"] is None
+    prebitcoin_timestamp = 1231006505 - 1
+    with pytest.raises(RpcError, match="Insane timestamp."):
+        minisafed.rpc.startrescan(prebitcoin_timestamp)
+    assert minisafed.rpc.getinfo()["rescan_progress"] is None
+
+    # First, get some coins
+    for _ in range(10):
+        addr = minisafed.rpc.getnewaddress()["address"]
+        amount = random.randint(1, COIN * 10) / COIN
+        txid = bitcoind.rpc.sendtoaddress(addr, amount)
+        bitcoind.generate_block(random.randint(1, 10), wait_for_mempool=txid)
+    wait_for(lambda: len(list_coins()) == 10)
+
+    # Then simulate some regular activity (spend and receive)
+    # TODO: instead of having randomness we should lay down all different cases (with or
+    # without change, single or multiple inputs, sending externally or to self).
+    for _ in range(5):
+        addr = minisafed.rpc.getnewaddress()["address"]
+        amount = random.randint(1, COIN * 10) / COIN
+        txid = bitcoind.rpc.sendtoaddress(addr, amount)
+        avail = list(unspent_coins())
+        to_spend = random.sample(avail, random.randint(1, len(avail)))
+        spend_coins(minisafed, bitcoind, to_spend)
+        bitcoind.generate_block(random.randint(1, 5), wait_for_mempool=2)
+        wait_for(lambda: all_spent(to_spend))
+    wait_for(
+        lambda: minisafed.rpc.getinfo()["blockheight"] == bitcoind.rpc.getblockcount()
+    )
+
+    # Move time forward one day as bitcoind will rescan the last 2 hours of block upon
+    # importing a descriptor.
+    now = int(time.time())
+    added_time = 60 * 60 * 24
+    bitcoind.rpc.setmocktime(now + added_time)
+    bitcoind.generate_block(10)
+
+    # Now delete the wallet state. When starting up we'll re-create a fresh database
+    # and watchonly wallet. Those won't be aware of past coins for the configured
+    # descriptor.
+    coins_before = sorted_coins()
+    minisafed.restart_fresh(bitcoind)
+    assert len(list_coins()) == 0
+
+    # Once the rescan is done, we must have detected all previous transactions.
+    minisafed.rpc.startrescan(initial_timestamp)
+    rescan_progress = minisafed.rpc.getinfo()["rescan_progress"]
+    assert rescan_progress is None or 0 <= rescan_progress <= 1
+    wait_for(lambda: minisafed.rpc.getinfo()["rescan_progress"] is None)
+    wait_for(
+        lambda: minisafed.rpc.getinfo()["blockheight"] == bitcoind.rpc.getblockcount()
+    )
+    assert coins_before == sorted_coins()

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -13,7 +13,8 @@ def test_getinfo(minisafed):
     res = minisafed.rpc.getinfo()
     assert res["version"] == "0.1"
     assert res["network"] == "regtest"
-    wait_for(lambda: res["blockheight"] == 101)
+    wait_for(lambda: minisafed.rpc.getinfo()["blockheight"] == 101)
+    res = minisafed.rpc.getinfo()
     assert res["sync"] == 1.0
     assert "main" in res["descriptors"]
     assert res["rescan_progress"] is None


### PR DESCRIPTION
This implements the ability for a user to rescan the block chain from an earlier timestamp to find transactions the wallet isn't currently aware of.

The main difficulty arises with the fact there are two rescans to be performed:
1. The block chain rescan on the Bitcoin backend. For the bitcoind implementation this means we need to rescan the bitcoind watchonly wallet down to the given timestamp (or height). We can imagine for an indexer backend such as an Electrum backend it could be almost instant.
2. The update of our state with the new state of the Bitcoin backend. In the poller we scan blocks linearly, we will never scan a block that we already scanned and that includes blocks anterior to the first block we scanned. In order to implement this rescan of past blocks after a Bitcoin backend rescan was performed we reused our current chain reorganization logic: we rewind our state down to the first block that was rescanned by the backend. This is overkill (we don't need to erase existing information), but sufficient for now.

The implementation is not as robust as it could be. Notably, in order to rescan the chain on the bitcoind implementation of the backend i use a trick to not make the connection block for the entire duration of the rescan when calling `importdescriptors`: i introduce a new client that has a timeout of 1 second and that ignores the response as well as timeout errors. Obviously this is problematic since it makes it more complicated to know whether the call actually succeeded.
~~A more robust solution would be to use `rescanblockchain` which starts the rescan without blocking but~~
1. We should be storing a height in the database, not a timestamp
2. The timestamp of the descriptors in the bitcoind watchonly wallet wouldn't be updated

EDIT: i'm dumb, `rescanblockchain` does block too!

I'm happy to have feedback on this. I think the current implementation is fine for now but eventually we should move to using `rescanblockchain` and get rid of the "noreply" client hack.

Also, some  functional tests for edge cases we could encounter are included but happy to have some more suggestions.

Fixes #28.