### PR TITLE
Derivation index update from the chain

### DIFF
--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -9,7 +9,7 @@ use std::{
     thread, time,
 };
 
-use miniscript::bitcoin;
+use miniscript::bitcoin::{self, secp256k1};
 
 #[derive(Debug, Clone)]
 struct UpdatedCoins {
@@ -28,6 +28,7 @@ fn update_coins(
     db_conn: &mut Box<dyn DatabaseConnection>,
     previous_tip: &BlockChainTip,
     descs: &[descriptors::InheritanceDescriptor],
+    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
 ) -> UpdatedCoins {
     let curr_coins = db_conn.coins();
     log::debug!("Current coins: {:?}", curr_coins);
@@ -35,9 +36,20 @@ fn update_coins(
     // Start by fetching newly received coins.
     let mut received = Vec::new();
     for utxo in bit.received_coins(previous_tip, descs) {
+        // We can only really treat them if we know the derivation index that was used.
         if let Some((derivation_index, is_change)) =
             db_conn.derivation_index_by_address(&utxo.address)
         {
+            // First of if we are receiving coins that are beyond our next derivation index,
+            // adjust it.
+            if derivation_index > db_conn.receive_index() {
+                db_conn.set_receive_index(derivation_index, secp);
+            }
+            if derivation_index > db_conn.change_index() {
+                db_conn.set_change_index(derivation_index, secp);
+            }
+
+            // Now record this coin as a newly received one.
             if !curr_coins.contains_key(&utxo.outpoint) {
                 let UTxO {
                     outpoint, amount, ..
@@ -55,6 +67,7 @@ fn update_coins(
                 received.push(coin);
             }
         } else {
+            // TODO: maybe we could try out something here? Like bruteforcing the next 200 indexes?
             log::error!(
                 "Could not get derivation index for coin '{}' (address: '{}')",
                 &utxo.outpoint,
@@ -170,6 +183,7 @@ fn updates(
     bit: &impl BitcoinInterface,
     db: &impl DatabaseInterface,
     descs: &[descriptors::InheritanceDescriptor],
+    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
 ) {
     let mut db_conn = db.connection();
 
@@ -183,18 +197,18 @@ fn updates(
             // between our former chain and the new one, then restart fresh.
             db_conn.rollback_tip(&new_tip);
             log::info!("Tip was rolled back to '{}'.", new_tip);
-            return updates(bit, db, descs);
+            return updates(bit, db, descs, secp);
         }
     };
 
     // Then check the state of our coins. Do it even if the tip did not change since last poll, as
     // we may have unconfirmed transactions.
-    let updated_coins = update_coins(bit, &mut db_conn, &current_tip, descs);
+    let updated_coins = update_coins(bit, &mut db_conn, &current_tip, descs, secp);
 
     // If the tip changed while we were polling our Bitcoin interface, start over.
     if bit.chain_tip() != latest_tip {
         log::info!("Chain tip changed while we were updating our state. Starting over.");
-        return updates(bit, db, descs);
+        return updates(bit, db, descs, secp);
     }
 
     // The chain tip did not change since we started our updates. Record them and the latest tip.
@@ -217,6 +231,7 @@ fn rescan_check(
     bit: &impl BitcoinInterface,
     db: &impl DatabaseInterface,
     descs: &[descriptors::InheritanceDescriptor],
+    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
 ) {
     log::debug!("Checking the state of an ongoing rescan if there is any");
     let mut db_conn = db.connection();
@@ -254,7 +269,7 @@ fn rescan_check(
             "Rolling back our internal tip to '{}' to update our internal state with past transactions.",
             rescan_tip
         );
-        updates(bit, db, descs)
+        updates(bit, db, descs, secp)
     } else {
         log::debug!("No ongoing rescan.");
     }
@@ -285,6 +300,7 @@ pub fn looper(
         desc.receive_descriptor().clone(),
         desc.change_descriptor().clone(),
     ];
+    let secp = secp256k1::Secp256k1::verification_only();
 
     maybe_initialize_tip(&bit, &db);
 
@@ -316,7 +332,7 @@ pub fn looper(
             }
         }
 
-        updates(&bit, &db, &descs);
-        rescan_check(&bit, &db, &descs);
+        updates(&bit, &db, &descs, &secp);
+        rescan_check(&bit, &db, &descs, &secp);
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -45,13 +45,25 @@ pub trait DatabaseConnection {
     /// Update our best chain seen.
     fn update_tip(&mut self, tip: &BlockChainTip);
 
+    /// Get the derivation index for the next receiving address
     fn receive_index(&mut self) -> bip32::ChildNumber;
 
+    /// Set the derivation index for the next receiving address
+    fn set_receive_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    );
+
+    /// Get the derivation index for the next change address
     fn change_index(&mut self) -> bip32::ChildNumber;
 
-    fn increment_receive_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
-
-    fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>);
+    /// Set the derivation index for the next change address
+    fn set_change_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    );
 
     /// Get the timestamp at which to start rescaning from, if any.
     fn rescan_timestamp(&mut self) -> Option<u32>;
@@ -131,16 +143,24 @@ impl DatabaseConnection for SqliteConn {
         self.db_wallet().deposit_derivation_index
     }
 
+    fn set_receive_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    ) {
+        self.set_derivation_index(index, false, secp)
+    }
+
     fn change_index(&mut self) -> bip32::ChildNumber {
         self.db_wallet().change_derivation_index
     }
 
-    fn increment_receive_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
-        self.increment_deposit_index(secp)
-    }
-
-    fn increment_change_index(&mut self, secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
-        self.increment_change_index(secp)
+    fn set_change_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    ) {
+        self.set_derivation_index(index, true, secp)
     }
 
     fn rescan_timestamp(&mut self) -> Option<u32> {

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -1,11 +1,8 @@
-use crate::database::sqlite::{
-    schema::{DbWallet, SCHEMA},
-    FreshDbOptions, SqliteDbError, DB_VERSION,
-};
+use crate::database::sqlite::{schema::SCHEMA, FreshDbOptions, SqliteDbError, DB_VERSION};
 
 use std::{convert::TryInto, fs, path, time};
 
-use miniscript::bitcoin::{self, secp256k1};
+use miniscript::bitcoin::secp256k1;
 
 pub const LOOK_AHEAD_LIMIT: u32 = 200;
 
@@ -134,34 +131,6 @@ pub fn create_fresh_db(
 
         Ok(())
     })?;
-
-    Ok(())
-}
-
-/// Insert the deposit and change addresses for this index in the address->index mapping table
-pub fn populate_address_mapping(
-    db_tx: &rusqlite::Transaction,
-    db_wallet: &DbWallet,
-    next_index: u32,
-    network: bitcoin::Network,
-    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
-) -> rusqlite::Result<()> {
-    // Update the address to derivation index mapping.
-    let next_la_index = next_index + LOOK_AHEAD_LIMIT - 1;
-    let next_receive_address = db_wallet
-        .main_descriptor
-        .receive_descriptor()
-        .derive(next_la_index.into(), secp)
-        .address(network);
-    let next_change_address = db_wallet
-        .main_descriptor
-        .change_descriptor()
-        .derive(next_la_index.into(), secp)
-        .address(network);
-    db_tx.execute(
-            "INSERT INTO addresses (receive_address, change_address, derivation_index) VALUES (?1, ?2, ?3)",
-            rusqlite::params![next_receive_address.to_string(), next_change_address.to_string(), next_la_index],
-        )?;
 
     Ok(())
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -145,18 +145,24 @@ impl DatabaseConnection for DummyDbConn {
         self.db.read().unwrap().deposit_index
     }
 
+    fn set_receive_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        _: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    ) {
+        self.db.write().unwrap().deposit_index = index;
+    }
+
     fn change_index(&mut self) -> bip32::ChildNumber {
         self.db.read().unwrap().deposit_index
     }
 
-    fn increment_receive_index(&mut self, _: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
-        let next_index = self.db.write().unwrap().deposit_index.increment().unwrap();
-        self.db.write().unwrap().deposit_index = next_index;
-    }
-
-    fn increment_change_index(&mut self, _: &secp256k1::Secp256k1<secp256k1::VerifyOnly>) {
-        let next_index = self.db.write().unwrap().change_index.increment().unwrap();
-        self.db.write().unwrap().change_index = next_index;
+    fn set_change_index(
+        &mut self,
+        index: bip32::ChildNumber,
+        _: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    ) {
+        self.db.write().unwrap().change_index = index;
     }
 
     fn coins(&mut self) -> HashMap<bitcoin::OutPoint, Coin> {


### PR DESCRIPTION
Currently, we wouldn't update our "next derivation index" to derive receive/change addresses if we noticed an address from a higher derivation index was used onchain. See #81. This fixes it.

Note that it can be tempting to set it with some leeway (for instance if we notice index `n` was used, we set our next derivation index to `n + 10`) since other wallets probably have generated addresses for more addresses than were actually used onchain.
However, i think it could have cascading effects in a multisig situation: A would use `n`, B would set its to `n + 10` and use `n + 11`, C would set its to `n + 21` and use `n + 22`. This is clear that we could end up very far indeed down the derivation tree without having used most indexes.

A functional test is included, demonstrating the behaviour after a rescan where we lost the database (and therefore knowledge of the previous "next derivation index"). It is in a separate commit to help reviewers attest it would fail on master and pass on this branch.